### PR TITLE
Impersonation

### DIFF
--- a/application/rest-api-adapter/src/main/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/AuthenticationFilter.java
+++ b/application/rest-api-adapter/src/main/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/AuthenticationFilter.java
@@ -19,16 +19,18 @@ import static java.util.Objects.nonNull;
 @AllArgsConstructor
 public class AuthenticationFilter extends OncePerRequestFilter {
     public final static String BEARER_PREFIX = "Bearer ";
+    public final static String IMPERSONATION_HEADER = "X-Impersonation-Claims";
     private final JwtService jwtService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest httpServletRequest,
                                     @NonNull HttpServletResponse httpServletResponse,
                                     @NonNull FilterChain filterChain) throws ServletException, IOException {
-        
+
         final String authorization = httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION);
+        final String impersonationHeader = httpServletRequest.getHeader(IMPERSONATION_HEADER);
         if (nonNull(authorization) && authorization.startsWith(BEARER_PREFIX)) {
-            jwtService.getAuthenticationFromJwt(authorization.replace(BEARER_PREFIX, "")).ifPresent(authentication -> {
+            jwtService.getAuthenticationFromJwt(authorization.replace(BEARER_PREFIX, ""), impersonationHeader).ifPresent(authentication -> {
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             });
         }

--- a/application/rest-api-adapter/src/main/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/AuthenticationService.java
+++ b/application/rest-api-adapter/src/main/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/AuthenticationService.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import onlydust.com.marketplace.api.domain.exception.OnlydustException;
 import onlydust.com.marketplace.api.domain.model.User;
-import onlydust.com.marketplace.api.rest.api.adapter.authentication.auth0.Auth0Authentication;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 
@@ -33,7 +32,6 @@ public class AuthenticationService {
             final OnlydustException unauthorized = OnlydustException.builder()
                     .message("Unauthorized")
                     .status(401)
-                    .rootException(((Auth0Authentication) authentication).getOnlydustException())
                     .build();
             LOGGER.warn(unauthorized.toString());
             throw unauthorized;

--- a/application/rest-api-adapter/src/main/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/JwtService.java
+++ b/application/rest-api-adapter/src/main/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/JwtService.java
@@ -3,5 +3,5 @@ package onlydust.com.marketplace.api.rest.api.adapter.authentication;
 import java.util.Optional;
 
 public interface JwtService {
-    Optional<OnlyDustAuthentication> getAuthenticationFromJwt(final String jwt);
+    Optional<OnlyDustAuthentication> getAuthenticationFromJwt(final String jwt, final String impersonationHeader);
 }

--- a/application/rest-api-adapter/src/main/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/OnlyDustAuthentication.java
+++ b/application/rest-api-adapter/src/main/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/OnlyDustAuthentication.java
@@ -4,6 +4,9 @@ import onlydust.com.marketplace.api.domain.model.User;
 import org.springframework.security.core.Authentication;
 
 public interface OnlyDustAuthentication extends Authentication {
-
     User getUser();
+
+    boolean isImpersonating();
+
+    User getImpersonator();
 }

--- a/application/rest-api-adapter/src/main/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/auth0/Auth0Authentication.java
+++ b/application/rest-api-adapter/src/main/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/auth0/Auth0Authentication.java
@@ -3,7 +3,6 @@ package onlydust.com.marketplace.api.rest.api.adapter.authentication.auth0;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import lombok.Builder;
 import lombok.Value;
-import onlydust.com.marketplace.api.domain.exception.OnlydustException;
 import onlydust.com.marketplace.api.domain.model.User;
 import onlydust.com.marketplace.api.rest.api.adapter.authentication.OnlyDustAuthentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -19,7 +18,9 @@ public class Auth0Authentication implements OnlyDustAuthentication {
     Collection<? extends GrantedAuthority> authorities;
     @Builder.Default
     Boolean isAuthenticated = false;
-    OnlydustException onlydustException;
+
+    User impersonator;
+    boolean impersonating;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -54,5 +55,15 @@ public class Auth0Authentication implements OnlyDustAuthentication {
     @Override
     public String getName() {
         return this.principal;
+    }
+
+    @Override
+    public boolean isImpersonating() {
+        return impersonating;
+    }
+
+    @Override
+    public User getImpersonator() {
+        return impersonator;
     }
 }

--- a/application/rest-api-adapter/src/main/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/auth0/Auth0JwtService.java
+++ b/application/rest-api-adapter/src/main/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/auth0/Auth0JwtService.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 
 @Slf4j
 public class Auth0JwtService implements JwtService {
+    private final static String IMPERSONATION_PERMISSION = "impersonation";
     private final static ObjectMapper objectMapper = new ObjectMapper();
     private final JWTVerifier jwtVerifier;
     private final UserFacadePort userFacadePort;
@@ -67,7 +68,7 @@ public class Auth0JwtService implements JwtService {
     }
 
     private Optional<OnlyDustAuthentication> getAuthenticationFromImpersonationHeader(DecodedJWT decodedJwt, User impersonator, final String impersonationHeader) {
-        if (!impersonator.getPermissions().contains("impersonation")) {
+        if (!impersonator.getPermissions().contains(IMPERSONATION_PERMISSION)) {
             LOGGER.warn("User {} is not allowed to impersonate", impersonator.getLogin());
             return Optional.empty();
         }

--- a/application/rest-api-adapter/src/main/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/auth0/Auth0JwtService.java
+++ b/application/rest-api-adapter/src/main/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/auth0/Auth0JwtService.java
@@ -27,7 +27,7 @@ public class Auth0JwtService implements JwtService {
         this.jwtVerifier = jwtVerifier;
     }
 
-    public Optional<OnlyDustAuthentication> getAuthenticationFromJwt(final String jwt) {
+    public Optional<OnlyDustAuthentication> getAuthenticationFromJwt(final String jwt, final String impersonationHeader) {
         try {
             final DecodedJWT decodedJwt = this.jwtVerifier.verify(jwt);
             final Auth0JwtClaims jwtClaims = objectMapper.readValue(Base64.getUrlDecoder().decode(decodedJwt.getPayload()),

--- a/application/rest-api-adapter/src/main/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/hasura/HasuraAuthentication.java
+++ b/application/rest-api-adapter/src/main/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/hasura/HasuraAuthentication.java
@@ -2,7 +2,6 @@ package onlydust.com.marketplace.api.rest.api.adapter.authentication.hasura;
 
 import lombok.Builder;
 import lombok.Value;
-import onlydust.com.marketplace.api.domain.exception.OnlydustException;
 import onlydust.com.marketplace.api.domain.model.User;
 import onlydust.com.marketplace.api.rest.api.adapter.authentication.OnlyDustAuthentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -20,7 +19,9 @@ public class HasuraAuthentication implements OnlyDustAuthentication {
     String principal;
     @Builder.Default
     Boolean isAuthenticated = false;
-    OnlydustException onlydustException;
+
+    User impersonator;
+    boolean impersonating;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -55,5 +56,15 @@ public class HasuraAuthentication implements OnlyDustAuthentication {
     @Override
     public String getName() {
         return this.principal;
+    }
+
+    @Override
+    public boolean isImpersonating() {
+        return impersonating;
+    }
+
+    @Override
+    public User getImpersonator() {
+        return impersonator;
     }
 }

--- a/application/rest-api-adapter/src/main/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/hasura/HasuraJwtService.java
+++ b/application/rest-api-adapter/src/main/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/hasura/HasuraJwtService.java
@@ -24,8 +24,8 @@ public class HasuraJwtService implements JwtService {
     private final static ObjectMapper objectMapper = new ObjectMapper();
     private final JwtSecret jwtSecret;
 
-    public Optional<OnlyDustAuthentication> getAuthenticationFromJwt(final String authorizationBearer) {
-        final String[] chunks = authorizationBearer.split("\\.");
+    public Optional<OnlyDustAuthentication> getAuthenticationFromJwt(final String jwt, final String impersonationHeader) {
+        final String[] chunks = jwt.split("\\.");
         if (chunks.length != 3) {
             LOGGER.warn("Invalid Jwt format");
             return Optional.empty();

--- a/application/rest-api-adapter/src/test/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/auth0/Auth0JwtServiceTest.java
+++ b/application/rest-api-adapter/src/test/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/auth0/Auth0JwtServiceTest.java
@@ -41,7 +41,7 @@ class Auth0JwtServiceTest {
                 .expiresAtLeeway(ONE_CENTURY)
                 .build());
         final Auth0JwtService auth0JwtService = new Auth0JwtService(jwtVerifier, userFacadePort);
-        final var authentication = auth0JwtService.getAuthenticationFromJwt(jwt).orElseThrow();
+        final var authentication = auth0JwtService.getAuthenticationFromJwt(jwt, null).orElseThrow();
 
         assertTrue(authentication.isAuthenticated());
         assertEquals("github|31901905", authentication.getName());
@@ -74,7 +74,7 @@ class Auth0JwtServiceTest {
                 .expiresAtLeeway(ONE_CENTURY)
                 .build());
         final Auth0JwtService auth0JwtService = new Auth0JwtService(jwtVerifier, userFacadePort);
-        final var authentication = auth0JwtService.getAuthenticationFromJwt(jwt);
+        final var authentication = auth0JwtService.getAuthenticationFromJwt(jwt, null);
 
         assertThat(authentication).isEmpty();
     }

--- a/application/rest-api-adapter/src/test/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/auth0/Auth0JwtServiceTest.java
+++ b/application/rest-api-adapter/src/test/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/auth0/Auth0JwtServiceTest.java
@@ -9,8 +9,6 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -20,6 +18,7 @@ class Auth0JwtServiceTest {
 
     @Test
     void should_authenticate_from_a_valid_jwt() {
+        // Given
         final UserFacadePort userFacadePort = mock(UserFacadePort.class);
         when(userFacadePort
                 .getUserByGithubIdentity(GithubUserIdentity.builder()
@@ -41,14 +40,20 @@ class Auth0JwtServiceTest {
                 .expiresAtLeeway(ONE_CENTURY)
                 .build());
         final Auth0JwtService auth0JwtService = new Auth0JwtService(jwtVerifier, userFacadePort);
+
+        // When
         final var authentication = auth0JwtService.getAuthenticationFromJwt(jwt, null).orElseThrow();
 
-        assertTrue(authentication.isAuthenticated());
-        assertEquals("github|31901905", authentication.getName());
+        // Then
+        assertThat(authentication.isAuthenticated()).isTrue();
+        assertThat(authentication.isImpersonating()).isFalse();
+        assertThat(authentication.getImpersonator()).isNull();
+        assertThat(authentication.getName()).isEqualTo("31901905");
 
-        final User user = (User) authentication.getDetails();
-        assertEquals("kaelsky", user.getLogin());
-        assertEquals(31901905, user.getGithubUserId());
+        final User user = authentication.getUser();
+        assertThat(user.getLogin()).isEqualTo("kaelsky");
+        assertThat(user.getGithubUserId()).isEqualTo(31901905);
+        assertThat(user.getPermissions()).containsExactlyInAnyOrder("me");
     }
 
     @Test
@@ -77,5 +82,125 @@ class Auth0JwtServiceTest {
         final var authentication = auth0JwtService.getAuthenticationFromJwt(jwt, null);
 
         assertThat(authentication).isEmpty();
+    }
+
+    @Test
+    void should_authenticate_given_a_valid_jwt_and_impersonation_header() {
+        // Given
+        final UserFacadePort userFacadePort = mock(UserFacadePort.class);
+        when(userFacadePort
+                .getUserByGithubIdentity(GithubUserIdentity.builder()
+                        .githubUserId(31901905L)
+                        .githubLogin("kaelsky")
+                        .githubAvatarUrl("https://avatars.githubusercontent.com/u/31901905?v=4")
+                        .build())
+        ).thenReturn(User.builder()
+                .id(UUID.randomUUID())
+                .login("kaelsky")
+                .avatarUrl("https://avatars.githubusercontent.com/u/31901905?v=4")
+                .githubUserId(31901905L)
+                .permissions(List.of("me", "impersonation"))
+                .build());
+
+        final String jwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IkQwa2xCQTBncnRhWTQxWmdqVHdSYyJ9.eyJuaWNrbmFtZSI6ImthZWxza3kiLCJuYW1lIjoiTWlja2FlbC5DIiwicGljdHVyZSI6Imh0dHBzOi8vYXZhdGFycy5naXRodWJ1c2VyY29udGVudC5jb20vdS8zMTkwMTkwNT92PTQiLCJ1cGRhdGVkX2F0IjoiMjAyMy0xMC0xMFQxMzo1NTo0OC4zMDhaIiwiaXNzIjoiaHR0cHM6Ly9vbmx5ZHVzdC1oYWNrYXRob24uZXUuYXV0aDAuY29tLyIsImF1ZCI6IjYyR0RnMmE2cENqbkFsbjFGY2NENTVlQ0tMSnRqNFQ1IiwiaWF0IjoxNjk2OTQ3OTMzLCJleHAiOjE2OTY5ODM5MzMsInN1YiI6ImdpdGh1YnwzMTkwMTkwNSIsInNpZCI6IjIxRkZFdDN5VTJFU0ZjVHRxVzV4QWlsUkZKMDRhdVViIiwibm9uY2UiOiJqNEN3WkkxMXV1VjN0RHp3cTRVeURFS2lXaUlnLVozZldXV1V6cDJVWElrIn0.MqeGFd6w3RuWTYwRHZ3s82P1C_SFOQJgLtOU6GYwe7KdigVaerPxjF8nwe8mrsg_g91_TpFxvpBlo3Hy6UiVrdN33HJjFGP29yJCYPR-PWCpt2rgboQCIuteq_OP4x6tdIL3ad0Ehm4PAeJZwg4RqKNPwj5EL0AV8tlNwN5elLG-9mVTZVWyEwV9xDgwAit4CJ4qGvheOhP-NQGIx4g9FElYy6Bw-XyI7rVFzT9h1Cxc3T2OWO2jgiuDVfHD_Q0Wz1uzD6s6eqPLuSNxmJtye7r-QOpuOgUIyVcKCs-WUuhhsQ4vad7lq3fmqUbSZ2xJPXBdwcfUZFfShAfAy3VK_g";
+        final Auth0JwtVerifier jwtVerifier = new Auth0JwtVerifier(Auth0Properties.builder()
+                .jwksUrl("https://onlydust-hackathon.eu.auth0.com/")
+                .expiresAtLeeway(ONE_CENTURY)
+                .build());
+
+        final String impersonationHeader = """
+                {
+                  "nickname": "ofux",
+                  "picture": "https://avatars.githubusercontent.com/u/595505?v=4",
+                  "sub": "github|595505"
+                }
+                """;
+        when(userFacadePort
+                .getUserByGithubIdentity(GithubUserIdentity.builder()
+                        .githubUserId(595505L)
+                        .githubLogin("ofux")
+                        .githubAvatarUrl("https://avatars.githubusercontent.com/u/595505?v=4")
+                        .build())
+        ).thenReturn(User.builder()
+                .id(UUID.randomUUID())
+                .login("ofux")
+                .avatarUrl("https://avatars.githubusercontent.com/u/595505?v=4")
+                .githubUserId(595505L)
+                .permissions(List.of("me"))
+                .build());
+
+        final Auth0JwtService auth0JwtService = new Auth0JwtService(jwtVerifier, userFacadePort);
+
+        // When
+        final var authentication = auth0JwtService.getAuthenticationFromJwt(jwt, impersonationHeader).orElseThrow();
+
+        // Then
+        assertThat(authentication.isAuthenticated()).isTrue();
+        assertThat(authentication.isImpersonating()).isTrue();
+        assertThat(authentication.getImpersonator()).isNotNull();
+        assertThat(authentication.getName()).isEqualTo("595505");
+
+        final User user = authentication.getUser();
+        assertThat(user.getLogin()).isEqualTo("ofux");
+        assertThat(user.getGithubUserId()).isEqualTo(595505L);
+        assertThat(user.getPermissions()).containsExactlyInAnyOrder("me");
+
+        final User impersonator = authentication.getImpersonator();
+        assertThat(impersonator.getLogin()).isEqualTo("kaelsky");
+        assertThat(impersonator.getGithubUserId()).isEqualTo(31901905L);
+    }
+
+    @Test
+    void should_reject_impersonation_when_impersonator_is_not_admin() {
+        // Given
+        final UserFacadePort userFacadePort = mock(UserFacadePort.class);
+        when(userFacadePort
+                .getUserByGithubIdentity(GithubUserIdentity.builder()
+                        .githubUserId(31901905L)
+                        .githubLogin("kaelsky")
+                        .githubAvatarUrl("https://avatars.githubusercontent.com/u/31901905?v=4")
+                        .build())
+        ).thenReturn(User.builder()
+                .id(UUID.randomUUID())
+                .login("kaelsky")
+                .avatarUrl("https://avatars.githubusercontent.com/u/31901905?v=4")
+                .githubUserId(31901905L)
+                .permissions(List.of("me"))
+                .build());
+
+        final String jwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IkQwa2xCQTBncnRhWTQxWmdqVHdSYyJ9.eyJuaWNrbmFtZSI6ImthZWxza3kiLCJuYW1lIjoiTWlja2FlbC5DIiwicGljdHVyZSI6Imh0dHBzOi8vYXZhdGFycy5naXRodWJ1c2VyY29udGVudC5jb20vdS8zMTkwMTkwNT92PTQiLCJ1cGRhdGVkX2F0IjoiMjAyMy0xMC0xMFQxMzo1NTo0OC4zMDhaIiwiaXNzIjoiaHR0cHM6Ly9vbmx5ZHVzdC1oYWNrYXRob24uZXUuYXV0aDAuY29tLyIsImF1ZCI6IjYyR0RnMmE2cENqbkFsbjFGY2NENTVlQ0tMSnRqNFQ1IiwiaWF0IjoxNjk2OTQ3OTMzLCJleHAiOjE2OTY5ODM5MzMsInN1YiI6ImdpdGh1YnwzMTkwMTkwNSIsInNpZCI6IjIxRkZFdDN5VTJFU0ZjVHRxVzV4QWlsUkZKMDRhdVViIiwibm9uY2UiOiJqNEN3WkkxMXV1VjN0RHp3cTRVeURFS2lXaUlnLVozZldXV1V6cDJVWElrIn0.MqeGFd6w3RuWTYwRHZ3s82P1C_SFOQJgLtOU6GYwe7KdigVaerPxjF8nwe8mrsg_g91_TpFxvpBlo3Hy6UiVrdN33HJjFGP29yJCYPR-PWCpt2rgboQCIuteq_OP4x6tdIL3ad0Ehm4PAeJZwg4RqKNPwj5EL0AV8tlNwN5elLG-9mVTZVWyEwV9xDgwAit4CJ4qGvheOhP-NQGIx4g9FElYy6Bw-XyI7rVFzT9h1Cxc3T2OWO2jgiuDVfHD_Q0Wz1uzD6s6eqPLuSNxmJtye7r-QOpuOgUIyVcKCs-WUuhhsQ4vad7lq3fmqUbSZ2xJPXBdwcfUZFfShAfAy3VK_g";
+        final Auth0JwtVerifier jwtVerifier = new Auth0JwtVerifier(Auth0Properties.builder()
+                .jwksUrl("https://onlydust-hackathon.eu.auth0.com/")
+                .expiresAtLeeway(ONE_CENTURY)
+                .build());
+
+        final String impersonationHeader = """
+                {
+                  "nickname": "ofux",
+                  "picture": "https://avatars.githubusercontent.com/u/595505?v=4",
+                  "sub": "github|595505"
+                }
+                """;
+        when(userFacadePort
+                .getUserByGithubIdentity(GithubUserIdentity.builder()
+                        .githubUserId(595505L)
+                        .githubLogin("ofux")
+                        .githubAvatarUrl("https://avatars.githubusercontent.com/u/595505?v=4")
+                        .build())
+        ).thenReturn(User.builder()
+                .id(UUID.randomUUID())
+                .login("ofux")
+                .avatarUrl("https://avatars.githubusercontent.com/u/595505?v=4")
+                .githubUserId(595505L)
+                .permissions(List.of("me"))
+                .build());
+
+        final Auth0JwtService auth0JwtService = new Auth0JwtService(jwtVerifier, userFacadePort);
+
+        // When
+        final var authentication = auth0JwtService.getAuthenticationFromJwt(jwt, impersonationHeader);
+
+        // Then
+        assertThat(authentication).isNotPresent();
     }
 }

--- a/application/rest-api-adapter/src/test/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/hasura/HasuraJwtServiceTest.java
+++ b/application/rest-api-adapter/src/test/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/hasura/HasuraJwtServiceTest.java
@@ -6,11 +6,11 @@ import onlydust.com.marketplace.api.rest.api.adapter.authentication.OnlyDustAuth
 import onlydust.com.marketplace.api.rest.api.adapter.authentication.jwt.JwtSecret;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HasuraJwtServiceTest {
@@ -30,6 +30,8 @@ public class HasuraJwtServiceTest {
                         .claims(
                                 HasuraJwtPayload.HasuraClaims.builder()
                                         .userId(UUID.randomUUID())
+                                        .login(faker.name().username())
+                                        .allowedRoles(List.of("me", "registered_user", "public"))
                                         .build()
                         )
                         .build();
@@ -42,12 +44,14 @@ public class HasuraJwtServiceTest {
         assertThat(authentication).isPresent();
         final var authenticationFromJwt = authentication.get();
         assertTrue(authenticationFromJwt.isAuthenticated());
-        assertEquals(authenticationFromJwt.getName(), hasuraJwtPayload.getSub());
-        assertEquals(authenticationFromJwt.getPrincipal(), hasuraJwtPayload.getSub());
-        assertEquals(authenticationFromJwt.getCredentials(), hasuraJwtPayload);
-        assertEquals(authenticationFromJwt.getUser().getId(), hasuraJwtPayload.getClaims().getUserId());
-        assertEquals(authenticationFromJwt.getUser().getPermissions(), hasuraJwtPayload.getClaims().getAllowedRoles());
-        assertEquals(authenticationFromJwt.getUser().getGithubUserId(), hasuraJwtPayload.getClaims().getGithubUserId());
+        assertThat(authenticationFromJwt.getName()).isEqualTo(hasuraJwtPayload.getClaims().getLogin());
+        assertThat(authenticationFromJwt.getPrincipal()).isEqualTo(hasuraJwtPayload.getClaims().getLogin());
+        assertThat(authenticationFromJwt.getCredentials()).isEqualTo(hasuraJwtPayload);
+        assertThat(authenticationFromJwt.getUser().getId()).isEqualTo(hasuraJwtPayload.getClaims().getUserId());
+        assertThat(authenticationFromJwt.getUser().getPermissions()).isEqualTo(hasuraJwtPayload.getClaims().getAllowedRoles());
+        assertThat(authenticationFromJwt.getUser().getGithubUserId()).isEqualTo(hasuraJwtPayload.getClaims().getGithubUserId());
+        assertThat(authenticationFromJwt.isImpersonating()).isFalse();
+        assertThat(authenticationFromJwt.getImpersonator()).isNull();
     }
 
 
@@ -94,6 +98,114 @@ public class HasuraJwtServiceTest {
         // When
         final Optional<OnlyDustAuthentication> authentication =
                 hasuraJwtService.getAuthenticationFromJwt(jwtToken, null);
+
+        // Then
+        assertThat(authentication).isNotPresent();
+    }
+
+    @Test
+    void should_authenticate_given_a_valid_jwt_and_impersonation_header() throws JsonProcessingException {
+        // Given
+        final JwtSecret jwtSecret = JwtSecret.builder().key(faker.cat().name()).issuer(faker.cat().breed()).type(
+                "HS256").build();
+        final HasuraJwtService hasuraJwtService = new HasuraJwtService(jwtSecret);
+        final HasuraJwtPayload hasuraJwtPayload =
+                HasuraJwtPayload.builder()
+                        .iss(jwtSecret.getIssuer())
+                        .sub(faker.rickAndMorty().character())
+                        .claims(
+                                HasuraJwtPayload.HasuraClaims.builder()
+                                        .userId(UUID.randomUUID())
+                                        .login(faker.name().username())
+                                        .isAnOnlydustAdmin(true)
+                                        .allowedRoles(List.of("me", "registered_user", "public", "impersonation"))
+                                        .build()
+                        )
+                        .build();
+        final String jwtToken = JwtHelper.generateValidJwtFor(jwtSecret, hasuraJwtPayload);
+
+        final String impersonationHeader = """
+                {
+                    "x-hasura-projectsLeaded": "{}",
+                    "x-hasura-githubUserId": "595505",
+                    "x-hasura-odAdmin": "false",
+                    "x-hasura-githubAccessToken": "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",
+                    "x-hasura-allowed-roles": [
+                      "me",
+                      "registered_user",
+                      "public"
+                    ],
+                    "x-hasura-default-role": "registered_user",
+                    "x-hasura-user-id": "50aa4318-141a-4027-8f74-c135d8d166b0",
+                    "x-hasura-user-is-anonymous": "false",
+                    "x-hasura-login": "ofux",
+                    "x-hasura-avatarUrl": "https://avatars.githubusercontent.com/u/595505?v=4"
+                }
+                """;
+
+        // When
+        final Optional<OnlyDustAuthentication> authentication = hasuraJwtService.getAuthenticationFromJwt(jwtToken, impersonationHeader);
+
+        // Then
+        assertThat(authentication).isPresent();
+        final var authenticationFromJwt = authentication.get();
+        assertTrue(authenticationFromJwt.isAuthenticated());
+        assertThat(authenticationFromJwt.getName()).isEqualTo("ofux");
+        assertThat(authenticationFromJwt.getPrincipal()).isEqualTo("ofux");
+        assertThat(authenticationFromJwt.getUser().getId().toString()).isEqualTo("50aa4318-141a-4027-8f74-c135d8d166b0");
+        assertThat(authenticationFromJwt.getUser().getPermissions()).containsExactlyInAnyOrder("me", "registered_user", "public");
+        assertThat(authenticationFromJwt.getUser().getGithubUserId()).isEqualTo(595505L);
+
+        assertThat(authenticationFromJwt.isImpersonating()).isTrue();
+        assertThat(authenticationFromJwt.getImpersonator()).isNotNull();
+        final var impersonator = authenticationFromJwt.getImpersonator();
+        assertThat(impersonator.getId()).isEqualTo(hasuraJwtPayload.getClaims().getUserId());
+        assertThat(impersonator.getPermissions()).isEqualTo(hasuraJwtPayload.getClaims().getAllowedRoles());
+        assertThat(impersonator.getGithubUserId()).isEqualTo(hasuraJwtPayload.getClaims().getGithubUserId());
+    }
+
+    @Test
+    void should_reject_impersonation_when_impersonator_is_not_admin() throws JsonProcessingException {
+        // Given
+        final JwtSecret jwtSecret = JwtSecret.builder().key(faker.cat().name()).issuer(faker.cat().breed()).type(
+                "HS256").build();
+        final HasuraJwtService hasuraJwtService = new HasuraJwtService(jwtSecret);
+        final HasuraJwtPayload hasuraJwtPayload =
+                HasuraJwtPayload.builder()
+                        .iss(jwtSecret.getIssuer())
+                        .sub(faker.rickAndMorty().character())
+                        .claims(
+                                HasuraJwtPayload.HasuraClaims.builder()
+                                        .userId(UUID.randomUUID())
+                                        .login(faker.name().username())
+                                        .isAnOnlydustAdmin(false)
+                                        .allowedRoles(List.of("me", "registered_user", "public"))
+                                        .build()
+                        )
+                        .build();
+        final String jwtToken = JwtHelper.generateValidJwtFor(jwtSecret, hasuraJwtPayload);
+
+        final String impersonationHeader = """
+                {
+                    "x-hasura-projectsLeaded": "{}",
+                    "x-hasura-githubUserId": "595505",
+                    "x-hasura-odAdmin": "false",
+                    "x-hasura-githubAccessToken": "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",
+                    "x-hasura-allowed-roles": [
+                      "me",
+                      "registered_user",
+                      "public"
+                    ],
+                    "x-hasura-default-role": "registered_user",
+                    "x-hasura-user-id": "50aa4318-141a-4027-8f74-c135d8d166b0",
+                    "x-hasura-user-is-anonymous": "false",
+                    "x-hasura-login": "foo",
+                    "x-hasura-avatarUrl": "https://avatars.githubusercontent.com/u/595505?v=4"
+                }
+                """;
+
+        // When
+        final Optional<OnlyDustAuthentication> authentication = hasuraJwtService.getAuthenticationFromJwt(jwtToken, impersonationHeader);
 
         // Then
         assertThat(authentication).isNotPresent();

--- a/application/rest-api-adapter/src/test/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/hasura/HasuraJwtServiceTest.java
+++ b/application/rest-api-adapter/src/test/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/hasura/HasuraJwtServiceTest.java
@@ -118,7 +118,7 @@ public class HasuraJwtServiceTest {
                                         .userId(UUID.randomUUID())
                                         .login(faker.name().username())
                                         .isAnOnlydustAdmin(true)
-                                        .allowedRoles(List.of("me", "registered_user", "public", "impersonation"))
+                                        .allowedRoles(List.of("me", "registered_user", "public"))
                                         .build()
                         )
                         .build();
@@ -160,7 +160,7 @@ public class HasuraJwtServiceTest {
         assertThat(authenticationFromJwt.getImpersonator()).isNotNull();
         final var impersonator = authenticationFromJwt.getImpersonator();
         assertThat(impersonator.getId()).isEqualTo(hasuraJwtPayload.getClaims().getUserId());
-        assertThat(impersonator.getPermissions()).isEqualTo(hasuraJwtPayload.getClaims().getAllowedRoles());
+        assertThat(impersonator.getPermissions()).containsExactlyInAnyOrder("me", "registered_user", "public", "impersonation");
         assertThat(impersonator.getGithubUserId()).isEqualTo(hasuraJwtPayload.getClaims().getGithubUserId());
     }
 

--- a/application/rest-api-adapter/src/test/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/hasura/HasuraJwtServiceTest.java
+++ b/application/rest-api-adapter/src/test/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/hasura/HasuraJwtServiceTest.java
@@ -36,7 +36,7 @@ public class HasuraJwtServiceTest {
         final String jwtToken = JwtHelper.generateValidJwtFor(jwtSecret, hasuraJwtPayload);
 
         // When
-        final Optional<OnlyDustAuthentication> authentication = hasuraJwtService.getAuthenticationFromJwt(jwtToken);
+        final Optional<OnlyDustAuthentication> authentication = hasuraJwtService.getAuthenticationFromJwt(jwtToken, null);
 
         // Then
         assertThat(authentication).isPresent();
@@ -60,7 +60,7 @@ public class HasuraJwtServiceTest {
 
         // When
         final Optional<OnlyDustAuthentication> authentication =
-                hasuraJwtService.getAuthenticationFromJwt(faker.chuckNorris().fact());
+                hasuraJwtService.getAuthenticationFromJwt(faker.chuckNorris().fact(), null);
 
         // Then
         assertThat(authentication).isNotPresent();
@@ -77,7 +77,7 @@ public class HasuraJwtServiceTest {
                 faker.cat().name() + "." + faker.pokemon().name() + "." + faker.pokemon().name();
 
         // When
-        final Optional<OnlyDustAuthentication> authentication = hasuraJwtService.getAuthenticationFromJwt(jwtToken);
+        final Optional<OnlyDustAuthentication> authentication = hasuraJwtService.getAuthenticationFromJwt(jwtToken, null);
 
         // Then
         assertThat(authentication).isNotPresent();
@@ -93,7 +93,7 @@ public class HasuraJwtServiceTest {
 
         // When
         final Optional<OnlyDustAuthentication> authentication =
-                hasuraJwtService.getAuthenticationFromJwt(jwtToken);
+                hasuraJwtService.getAuthenticationFromJwt(jwtToken, null);
 
         // Then
         assertThat(authentication).isNotPresent();

--- a/domain/src/main/java/onlydust/com/marketplace/api/domain/model/User.java
+++ b/domain/src/main/java/onlydust/com/marketplace/api/domain/model/User.java
@@ -3,6 +3,7 @@ package onlydust.com.marketplace.api.domain.model;
 import lombok.Builder;
 import lombok.Data;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -10,7 +11,8 @@ import java.util.UUID;
 @Builder(toBuilder = true)
 public class User {
     UUID id;
-    List<String> permissions;
+    @Builder.Default
+    List<String> permissions = new ArrayList<>();
     Long githubUserId;
     String avatarUrl;
     String login;


### PR DESCRIPTION
Handle impersonation for both Hasura and Auth0.

To impersonate, the frontend must send valid claims (JSON format) in the `X-Impersonation-Claims` header.

When authentication is done via Hasura, impersonation claims must be of the following form:

```json
{
                    "x-hasura-projectsLeaded": "{}",
                    "x-hasura-githubUserId": "595505",
                    "x-hasura-odAdmin": "false",
                    "x-hasura-githubAccessToken": "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",
                    "x-hasura-allowed-roles": [
                      "me",
                      "registered_user",
                      "public"
                    ],
                    "x-hasura-default-role": "registered_user",
                    "x-hasura-user-id": "50aa4318-141a-4027-8f74-c135d8d166b0",
                    "x-hasura-user-is-anonymous": "false",
                    "x-hasura-login": "foo",
                    "x-hasura-avatarUrl": "https://avatars.githubusercontent.com/u/595505?v=4"
                }
```

When authentication is done via Auth0, impersonation claims must be of the following form:

```json
{
                  "nickname": "ofux",
                  "picture": "https://avatars.githubusercontent.com/u/595505?v=4",
                  "sub": "github|595505"
                }
```

It is up to the frontend to send appropriate impersonation claims.