### PR TITLE
Fix performance issues on FIND_TOP_CONTRIBUTORS_BASE_QUERY

### DIFF
--- a/infrastructure/postgres-adapter/src/main/java/onlydust/com/marketplace/api/postgres/adapter/repository/CustomContributorRepository.java
+++ b/infrastructure/postgres-adapter/src/main/java/onlydust/com/marketplace/api/postgres/adapter/repository/CustomContributorRepository.java
@@ -25,7 +25,7 @@ public class CustomContributorRepository {
             			contributions c
             		WHERE
             			c.user_id = gu.id
-            			AND c.repo_id = ANY ((select array(select pgr.github_repo_id from project_github_repos pgr where pgr.project_id = :projectId))::bigint[])
+            			AND c.repo_id = ANY ((select array(select pgr.github_repo_id from project_github_repos pgr where pgr.project_id = :projectId))\\:\\:bigint[])
             			AND c.status = 'complete') AS contribution_count,
             		gu.*
             	FROM

--- a/infrastructure/postgres-adapter/src/main/java/onlydust/com/marketplace/api/postgres/adapter/repository/CustomContributorRepository.java
+++ b/infrastructure/postgres-adapter/src/main/java/onlydust/com/marketplace/api/postgres/adapter/repository/CustomContributorRepository.java
@@ -23,10 +23,9 @@ public class CustomContributorRepository {
             			count(*)
             		FROM
             			contributions c
-            			JOIN project_github_repos pgr ON pgr.project_id = :projectId
-            				AND pgr.github_repo_id = c.repo_id
             		WHERE
             			c.user_id = gu.id
+            			AND c.repo_id = ANY ((select array(select pgr.github_repo_id from project_github_repos pgr where pgr.project_id = :projectId))::bigint[])
             			AND c.status = 'complete') AS contribution_count,
             		gu.*
             	FROM
@@ -43,24 +42,6 @@ public class CustomContributorRepository {
                 from projects_contributors pc
                 where pc.project_id = :projectId
             """;
-
-    private final EntityManager entityManager;
-
-    public List<GithubUserViewEntity> findProjectTopContributors(UUID projectId, int limit) {
-        return entityManager
-                .createNativeQuery(FIND_TOP_CONTRIBUTORS_BASE_QUERY, GithubUserViewEntity.class)
-                .setParameter("projectId", projectId)
-                .setParameter("limit", limit)
-                .getResultList();
-    }
-
-    public Integer getProjectContributorCount(UUID projectId) {
-        final var query = entityManager
-                .createNativeQuery(GET_CONTRIBUTOR_COUNT)
-                .setParameter("projectId", projectId);
-        return ((Number) query.getSingleResult()).intValue();
-    }
-
     protected static final String GET_CONTRIBUTORS_FOR_PROJECT = """
             select gu.id,
                    gu.login,
@@ -103,16 +84,7 @@ public class CustomContributorRepository {
             order by %order_by%
             offset %offset% limit %limit%
             """;
-
-
-    public List<ProjectContributorViewEntity> getProjectContributorViewEntity(final UUID projectId,
-                                                                              ProjectContributorsLinkView.SortBy sortBy,
-                                                                              int pageIndex, int pageSize) {
-        return entityManager.createNativeQuery(buildQuery(sortBy, pageIndex, pageSize),
-                        ProjectContributorViewEntity.class)
-                .setParameter("projectId", projectId)
-                .getResultList();
-    }
+    private final EntityManager entityManager;
 
     static protected String buildQuery(ProjectContributorsLinkView.SortBy sortBy,
                                        int pageIndex, int pageSize) {
@@ -129,5 +101,29 @@ public class CustomContributorRepository {
                 .replace("%limit%",
                         PaginationMapper.getPostgresLimitFromPagination(pageSize, pageIndex).toString())
                 .replace("%order_by%", sortValue);
+    }
+
+    public List<GithubUserViewEntity> findProjectTopContributors(UUID projectId, int limit) {
+        return entityManager
+                .createNativeQuery(FIND_TOP_CONTRIBUTORS_BASE_QUERY, GithubUserViewEntity.class)
+                .setParameter("projectId", projectId)
+                .setParameter("limit", limit)
+                .getResultList();
+    }
+
+    public Integer getProjectContributorCount(UUID projectId) {
+        final var query = entityManager
+                .createNativeQuery(GET_CONTRIBUTOR_COUNT)
+                .setParameter("projectId", projectId);
+        return ((Number) query.getSingleResult()).intValue();
+    }
+
+    public List<ProjectContributorViewEntity> getProjectContributorViewEntity(final UUID projectId,
+                                                                              ProjectContributorsLinkView.SortBy sortBy,
+                                                                              int pageIndex, int pageSize) {
+        return entityManager.createNativeQuery(buildQuery(sortBy, pageIndex, pageSize),
+                        ProjectContributorViewEntity.class)
+                .setParameter("projectId", projectId)
+                .getResultList();
     }
 }


### PR DESCRIPTION
I NEED to post a comment, because this is just black magic.

This query was very slow for a specific project. After trying many things, my guess is that is was slow for this specific project because it has many contributors (> 2k) AND more than *3* repos. Don't ask me why *3*, but it does seem to be a magical number that changes everything here.

So, here is the slow query:

```sql
  SELECT
         	(
            		SELECT
            			count(c.id)
            		FROM
            			public.contributions c
            			JOIN project_github_repos pgr ON pgr.project_id = 'dc60d963-4b5f-4a96-928c-8440b4657138'
            				AND pgr.github_repo_id = c.repo_id
            		WHERE
            			c.user_id = gu.id
            			AND c.status = 'complete'
            		) AS contribution_count,
            		gu.*
            	FROM
            		public.github_users gu
            		JOIN public.projects_contributors pc ON pc.github_user_id = gu.id
            			AND pc.project_id = 'dc60d963-4b5f-4a96-928c-8440b4657138'
            		
             		ORDER BY
             			contribution_count DESC, gu.id
            		LIMIT 3;
```

My first guess was to try to change the JOIN of the subquery into an EXISTS, even though it should be equivalent. But it was just as slow:

```sql
  SELECT
            	(
            		SELECT
            			count(c.id)
            		FROM
            			public.contributions c
            		WHERE
            			c.user_id = gu.id
            			AND c.status = 'complete'
              			AND EXISTS(select 1 from project_github_repos pgr where pgr.project_id = 'dc60d963-4b5f-4a96-928c-8440b4657138' and pgr.github_repo_id = c.repo_id)
            		) AS contribution_count,
            		gu.*
            	FROM
            		public.github_users gu
            		JOIN public.projects_contributors pc ON pc.github_user_id = gu.id
            			AND pc.project_id = 'dc60d963-4b5f-4a96-928c-8440b4657138'
            		
             		ORDER BY
             			contribution_count DESC, gu.id
            		LIMIT 3;
```

Now, let's try with a IN, but again, no improvement:

```sql
  SELECT
            	(
            		SELECT
            			count(c.id)
            		FROM
            			public.contributions c
            		WHERE
            			c.user_id = gu.id
            			AND c.status = 'complete'
            			AND c.repo_id IN (select pgr.github_repo_id from project_github_repos pgr where pgr.project_id = 'dc60d963-4b5f-4a96-928c-8440b4657138')
            		) AS contribution_count,
            		gu.*
            	FROM
            		public.github_users gu
            		JOIN public.projects_contributors pc ON pc.github_user_id = gu.id
            			AND pc.project_id = 'dc60d963-4b5f-4a96-928c-8440b4657138'
            		
             		ORDER BY
             			contribution_count DESC, gu.id
            		LIMIT 3;
```

Now here is the interesting part. Replace the IN subquery with the hard-coded list of repo ids, and the query becomes suddenly very fast!

```sql
  SELECT
            	(
            		SELECT
            			count(c.id)
            		FROM
            			public.contributions c
            		WHERE
            			c.user_id = gu.id
            			AND c.status = 'complete'
            			AND c.repo_id IN (593701982, 78853160, 326478752, 10270250)
            		) AS contribution_count,
            		gu.*
            	FROM
            		public.github_users gu
            		JOIN public.projects_contributors pc ON pc.github_user_id = gu.id
            			AND pc.project_id = 'dc60d963-4b5f-4a96-928c-8440b4657138'
            		
             		ORDER BY
             			contribution_count DESC, gu.id
            		LIMIT 3;
```

It's pretty clear now that Postgres messes up at some point and run the subquery `select pgr.github_repo_id from project_github_repos pgr where pgr.project_id = 'dc60d963-4b5f-4a96-928c-8440b4657138'` on every row instead of running it once for the whole query. Don't ask me why.

So now, here is the trick. To force postgres running this only once, just add a bit of black magic: replace the 

```sql
c.repo_id IN (select pgr.github_repo_id from project_github_repos pgr where pgr.project_id = 'dc60d963-4b5f-4a96-928c-8440b4657138')
```

with:

```sql
AND c.repo_id = ANY ((select array(select pgr.github_repo_id from project_github_repos pgr where pgr.project_id = 'dc60d963-4b5f-4a96-928c-8440b4657138'))::bigint[])
```

Tada! This is fast. Don't. Ask. Me. Why.