### PR TITLE
Revamp accounting domain using account book

### DIFF
--- a/accounting-domain/src/main/java/onlydust/com/marketplace/accounting/domain/CommitteeAccountProvider.java
+++ b/accounting-domain/src/main/java/onlydust/com/marketplace/accounting/domain/CommitteeAccountProvider.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 
 public interface CommitteeAccountProvider {
     Optional<Account> get(CommitteeId committeeId, Currency currency);
+
+    Account create(CommitteeId committeeId, Currency currency);
 }

--- a/accounting-domain/src/main/java/onlydust/com/marketplace/accounting/domain/SponsorAccountProvider.java
+++ b/accounting-domain/src/main/java/onlydust/com/marketplace/accounting/domain/SponsorAccountProvider.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 
 public interface SponsorAccountProvider {
     Optional<Account> get(SponsorId sponsorId, Currency currency);
+
+    Account create(SponsorId sponsorId, Currency currency);
 }

--- a/accounting-domain/src/main/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingService.java
+++ b/accounting-domain/src/main/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingService.java
@@ -1,0 +1,22 @@
+package onlydust.com.marketplace.accounting.domain;
+
+import lombok.AllArgsConstructor;
+import onlydust.com.marketplace.accounting.domain.model.Currency;
+import onlydust.com.marketplace.accounting.domain.model.PositiveAmount;
+import onlydust.com.marketplace.accounting.domain.model.PositiveMoney;
+import onlydust.com.marketplace.accounting.domain.model.SponsorId;
+import onlydust.com.marketplace.accounting.domain.port.out.CurrencyStorage;
+
+@AllArgsConstructor
+public class SponsorAccountingService {
+
+    private final SponsorAccountProvider sponsorAccountProvider;
+    private final CurrencyStorage currencyStorage;
+
+    public void receiveFrom(SponsorId sponsorId, PositiveAmount amount, Currency.Id id) {
+        final var currency = currencyStorage.get(id).orElseThrow();
+        final var account = sponsorAccountProvider.get(sponsorId, currency)
+                .orElseGet(() -> sponsorAccountProvider.create(sponsorId, currency));
+        account.mint(PositiveMoney.of(PositiveMoney.of(amount, currency)));
+    }
+}

--- a/accounting-domain/src/main/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingService.java
+++ b/accounting-domain/src/main/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingService.java
@@ -6,6 +6,7 @@ import onlydust.com.marketplace.accounting.domain.model.PositiveAmount;
 import onlydust.com.marketplace.accounting.domain.model.PositiveMoney;
 import onlydust.com.marketplace.accounting.domain.model.SponsorId;
 import onlydust.com.marketplace.accounting.domain.port.out.CurrencyStorage;
+import onlydust.com.marketplace.kernel.exception.OnlyDustException;
 
 @AllArgsConstructor
 public class SponsorAccountingService {
@@ -18,5 +19,12 @@ public class SponsorAccountingService {
         final var account = sponsorAccountProvider.get(sponsorId, currency)
                 .orElseGet(() -> sponsorAccountProvider.create(sponsorId, currency));
         account.mint(PositiveMoney.of(PositiveMoney.of(amount, currency)));
+    }
+
+    public void refundTo(SponsorId sponsorId, PositiveAmount amount, Currency.Id id) {
+        final var currency = currencyStorage.get(id).orElseThrow();
+        final var account = sponsorAccountProvider.get(sponsorId, currency)
+                .orElseThrow(() -> OnlyDustException.notFound("No account found for sponsor %s in currency %s".formatted(sponsorId, currency)));
+        account.burn(PositiveMoney.of(PositiveMoney.of(amount, currency)));
     }
 }

--- a/accounting-domain/src/main/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingService.java
+++ b/accounting-domain/src/main/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingService.java
@@ -41,6 +41,11 @@ public class SponsorAccountingService {
                 .orElseGet(() -> committeeAccountProvider.create(committeeId, currency));
     }
 
+    private Account getAccount(CommitteeId committeeId, Currency currency) {
+        return committeeAccountProvider.get(committeeId, currency)
+                .orElseThrow(() -> OnlyDustException.notFound("No account found for committee %s in currency %s".formatted(committeeId, currency)));
+    }
+
     private Currency getCurrency(Currency.Id id) {
         return currencyStorage.get(id)
                 .orElseThrow(() -> OnlyDustException.notFound("Currency %s not found".formatted(id)));
@@ -52,5 +57,13 @@ public class SponsorAccountingService {
         final var committeeAccount = getOrCreateAccount(committeeId, currency);
 
         sponsorAccount.send(committeeAccount, PositiveMoney.of(amount, currency));
+    }
+
+    public void unallocate(SponsorId sponsorId, CommitteeId committeeId, PositiveAmount amount, Currency.Id currencyId) {
+        final var currency = getCurrency(currencyId);
+        final var sponsorAccount = getAccount(sponsorId, currency);
+        final var committeeAccount = getAccount(committeeId, currency);
+
+        committeeAccount.refund(sponsorAccount, PositiveMoney.of(amount, currency));
     }
 }

--- a/accounting-domain/src/main/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingService.java
+++ b/accounting-domain/src/main/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingService.java
@@ -15,14 +15,18 @@ public class SponsorAccountingService {
     private final CurrencyStorage currencyStorage;
 
     public void receiveFrom(SponsorId sponsorId, PositiveAmount amount, Currency.Id id) {
-        final var currency = currencyStorage.get(id).orElseThrow();
+        final var currency = currencyStorage.get(id)
+                .orElseThrow(() -> OnlyDustException.notFound("Currency %s not found".formatted(id)));
+
         final var account = sponsorAccountProvider.get(sponsorId, currency)
                 .orElseGet(() -> sponsorAccountProvider.create(sponsorId, currency));
+
         account.mint(PositiveMoney.of(PositiveMoney.of(amount, currency)));
     }
 
     public void refundTo(SponsorId sponsorId, PositiveAmount amount, Currency.Id id) {
-        final var currency = currencyStorage.get(id).orElseThrow();
+        final var currency = currencyStorage.get(id)
+                .orElseThrow(() -> OnlyDustException.notFound("Currency %s not found".formatted(id)));
         final var account = sponsorAccountProvider.get(sponsorId, currency)
                 .orElseThrow(() -> OnlyDustException.notFound("No account found for sponsor %s in currency %s".formatted(sponsorId, currency)));
         account.burn(PositiveMoney.of(PositiveMoney.of(amount, currency)));

--- a/accounting-domain/src/main/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingService.java
+++ b/accounting-domain/src/main/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingService.java
@@ -1,10 +1,7 @@
 package onlydust.com.marketplace.accounting.domain;
 
 import lombok.AllArgsConstructor;
-import onlydust.com.marketplace.accounting.domain.model.Currency;
-import onlydust.com.marketplace.accounting.domain.model.PositiveAmount;
-import onlydust.com.marketplace.accounting.domain.model.PositiveMoney;
-import onlydust.com.marketplace.accounting.domain.model.SponsorId;
+import onlydust.com.marketplace.accounting.domain.model.*;
 import onlydust.com.marketplace.accounting.domain.port.out.CurrencyStorage;
 import onlydust.com.marketplace.kernel.exception.OnlyDustException;
 
@@ -14,21 +11,32 @@ public class SponsorAccountingService {
     private final SponsorAccountProvider sponsorAccountProvider;
     private final CurrencyStorage currencyStorage;
 
-    public void receiveFrom(SponsorId sponsorId, PositiveAmount amount, Currency.Id id) {
-        final var currency = currencyStorage.get(id)
-                .orElseThrow(() -> OnlyDustException.notFound("Currency %s not found".formatted(id)));
-
-        final var account = sponsorAccountProvider.get(sponsorId, currency)
-                .orElseGet(() -> sponsorAccountProvider.create(sponsorId, currency));
+    public void receiveFrom(SponsorId sponsorId, PositiveAmount amount, Currency.Id currencyId) {
+        final var currency = getCurrency(currencyId);
+        final var account = getOrCreateAccount(sponsorId, currency);
 
         account.mint(PositiveMoney.of(PositiveMoney.of(amount, currency)));
     }
 
-    public void refundTo(SponsorId sponsorId, PositiveAmount amount, Currency.Id id) {
-        final var currency = currencyStorage.get(id)
-                .orElseThrow(() -> OnlyDustException.notFound("Currency %s not found".formatted(id)));
-        final var account = sponsorAccountProvider.get(sponsorId, currency)
-                .orElseThrow(() -> OnlyDustException.notFound("No account found for sponsor %s in currency %s".formatted(sponsorId, currency)));
+    public void refundTo(SponsorId sponsorId, PositiveAmount amount, Currency.Id currencyId) {
+        final var currency = getCurrency(currencyId);
+        final var account = getAccount(sponsorId, currency);
+
         account.burn(PositiveMoney.of(PositiveMoney.of(amount, currency)));
+    }
+
+    private Account getOrCreateAccount(SponsorId sponsorId, Currency currency) {
+        return sponsorAccountProvider.get(sponsorId, currency)
+                .orElseGet(() -> sponsorAccountProvider.create(sponsorId, currency));
+    }
+
+    private Account getAccount(SponsorId sponsorId, Currency currency) {
+        return sponsorAccountProvider.get(sponsorId, currency)
+                .orElseThrow(() -> OnlyDustException.notFound("No account found for sponsor %s in currency %s".formatted(sponsorId, currency)));
+    }
+
+    private Currency getCurrency(Currency.Id id) {
+        return currencyStorage.get(id)
+                .orElseThrow(() -> OnlyDustException.notFound("Currency %s not found".formatted(id)));
     }
 }

--- a/accounting-domain/src/main/java/onlydust/com/marketplace/accounting/domain/model/PositiveMoney.java
+++ b/accounting-domain/src/main/java/onlydust/com/marketplace/accounting/domain/model/PositiveMoney.java
@@ -18,6 +18,10 @@ public class PositiveMoney extends Money {
         }
     }
 
+    public static @NonNull PositiveMoney of(PositiveAmount amount, Currency currency) {
+        return new PositiveMoney(amount.value, currency);
+    }
+
     public static @NonNull PositiveMoney of(BigDecimal value, Currency currency) {
         return new PositiveMoney(value, currency);
     }

--- a/accounting-domain/src/test/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingServiceTest.java
+++ b/accounting-domain/src/test/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingServiceTest.java
@@ -68,6 +68,27 @@ public class SponsorAccountingServiceTest {
         assertThat(account.balance()).isEqualTo(Money.of(110L, currency));
     }
 
+
+    /*
+     * Given a sponsor with an account
+     * When I transfer money to OnlyDust in an unknown currency
+     * Then The transfer is rejected
+     */
+    @Test
+    void should_reject_transfer_when_unknown_currency() {
+        // Given
+        final var sponsorId = SponsorId.random();
+        final var currencyId = Currency.Id.random();
+
+        when(currencyStorage.get(currencyId)).thenReturn(Optional.empty());
+
+        // When
+        assertThatThrownBy(() -> sponsorAccountingService.receiveFrom(sponsorId, PositiveAmount.of(10L), currencyId))
+                // Then
+                .isInstanceOf(OnlyDustException.class)
+                .hasMessage("Currency %s not found".formatted(currencyId));
+    }
+
     /*
      * Given a sponsor with an account
      * When I refund money from OnlyDust
@@ -109,5 +130,25 @@ public class SponsorAccountingServiceTest {
                 // Then
                 .isInstanceOf(OnlyDustException.class)
                 .hasMessage("No account found for sponsor %s in currency %s".formatted(sponsorId, currency));
+    }
+
+    /*
+     * Given a sponsor with an account
+     * When I refund money from OnlyDust in an unknown currency
+     * Then The refund is rejected
+     */
+    @Test
+    void should_reject_refund_when_unknown_currency() {
+        // Given
+        final var sponsorId = SponsorId.random();
+        final var currencyId = Currency.Id.random();
+
+        when(currencyStorage.get(currencyId)).thenReturn(Optional.empty());
+
+        // When
+        assertThatThrownBy(() -> sponsorAccountingService.refundTo(sponsorId, PositiveAmount.of(10L), currencyId))
+                // Then
+                .isInstanceOf(OnlyDustException.class)
+                .hasMessage("Currency %s not found".formatted(currencyId));
     }
 }

--- a/accounting-domain/src/test/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingServiceTest.java
+++ b/accounting-domain/src/test/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingServiceTest.java
@@ -65,4 +65,26 @@ public class SponsorAccountingServiceTest {
         // Then
         assertThat(account.balance()).isEqualTo(Money.of(110L, currency));
     }
+
+    /*
+     * Given a sponsor with an account
+     * When I refund money from OnlyDust
+     * Then The refund is registered on my account
+     */
+    @Test
+    void should_register_refund() {
+        // Given
+        final var sponsorId = SponsorId.random();
+        final var currency = Currencies.USD;
+        final var account = new Account(PositiveMoney.of(100L, currency));
+
+        when(currencyStorage.get(currency.id())).thenReturn(Optional.of(currency));
+        when(sponsorAccountProvider.get(sponsorId, currency)).thenReturn(Optional.of(account));
+
+        // When
+        sponsorAccountingService.refundTo(sponsorId, PositiveAmount.of(10L), currency.id());
+
+        // Then
+        assertThat(account.balance()).isEqualTo(Money.of(90L, currency));
+    }
 }

--- a/accounting-domain/src/test/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingServiceTest.java
+++ b/accounting-domain/src/test/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingServiceTest.java
@@ -6,7 +6,6 @@ import onlydust.com.marketplace.accounting.domain.stubs.Currencies;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.math.BigDecimal;
 import java.util.Optional;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
@@ -43,5 +42,27 @@ public class SponsorAccountingServiceTest {
 
         // Then
         assertThat(account.balance()).isEqualTo(Money.of(10L, currency));
+    }
+
+    /*
+     * Given a sponsor with an account
+     * When I transfer money to OnlyDust
+     * Then The transfer is registered on my account
+     */
+    @Test
+    void should_register_transfer() {
+        // Given
+        final var sponsorId = SponsorId.random();
+        final var currency = Currencies.USD;
+        final var account = new Account(PositiveMoney.of(100L, currency));
+
+        when(currencyStorage.get(currency.id())).thenReturn(Optional.of(currency));
+        when(sponsorAccountProvider.get(sponsorId, currency)).thenReturn(Optional.of(account));
+
+        // When
+        sponsorAccountingService.receiveFrom(sponsorId, PositiveAmount.of(10L), currency.id());
+
+        // Then
+        assertThat(account.balance()).isEqualTo(Money.of(110L, currency));
     }
 }

--- a/accounting-domain/src/test/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingServiceTest.java
+++ b/accounting-domain/src/test/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingServiceTest.java
@@ -256,4 +256,25 @@ public class SponsorAccountingServiceTest {
         assertThat(committeeAccount.balance()).isEqualTo(Money.of(205L, currency));
         assertThat(committeeAccount.balanceFrom(sponsorAccount.getId())).isEqualTo(Money.of(5L, currency));
     }
+
+    /*
+     * Given a sponsor that has allocated money to a committee
+     * When I refund money from the committee in an unknown currency
+     * Then The refund is rejected
+     */
+    @Test
+    void should_reject_unallocation_when_unknown_currency() {
+        // Given
+        final var sponsorId = SponsorId.random();
+        final var committeeId = CommitteeId.random();
+        final var currencyId = Currency.Id.random();
+
+        when(currencyStorage.get(currencyId)).thenReturn(Optional.empty());
+
+        // When
+        assertThatThrownBy(() -> sponsorAccountingService.unallocate(sponsorId, committeeId, PositiveAmount.of(10L), currencyId))
+                // Then
+                .isInstanceOf(OnlyDustException.class)
+                .hasMessage("Currency %s not found".formatted(currencyId));
+    }
 }

--- a/accounting-domain/src/test/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingServiceTest.java
+++ b/accounting-domain/src/test/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingServiceTest.java
@@ -207,4 +207,25 @@ public class SponsorAccountingServiceTest {
         assertThat(committeeAccount.balance()).isEqualTo(Money.of(10L, currency));
         assertThat(committeeAccount.balanceFrom(sponsorAccount.getId())).isEqualTo(Money.of(10L, currency));
     }
+
+    /*
+     * Given a sponsor with an account
+     * When I allocate money to a committee in an unknown currency
+     * Then The allocation is rejected
+     */
+    @Test
+    void should_reject_allocation_when_unknown_currency() {
+        // Given
+        final var sponsorId = SponsorId.random();
+        final var committeeId = CommitteeId.random();
+        final var currencyId = Currency.Id.random();
+
+        when(currencyStorage.get(currencyId)).thenReturn(Optional.empty());
+
+        // When
+        assertThatThrownBy(() -> sponsorAccountingService.allocate(sponsorId, committeeId, PositiveAmount.of(10L), currencyId))
+                // Then
+                .isInstanceOf(OnlyDustException.class)
+                .hasMessage("Currency %s not found".formatted(currencyId));
+    }
 }

--- a/accounting-domain/src/test/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingServiceTest.java
+++ b/accounting-domain/src/test/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingServiceTest.java
@@ -179,4 +179,32 @@ public class SponsorAccountingServiceTest {
         assertThat(committeeAccount.balance()).isEqualTo(Money.of(210L, currency));
         assertThat(committeeAccount.balanceFrom(sponsorAccount.getId())).isEqualTo(Money.of(10L, currency));
     }
+
+    /*
+     * Given a sponsor with an account
+     * When I allocate money to a committee with no account
+     * Then An account is created for the committee and the transfer is registered from my account to the committee account
+     */
+    @Test
+    void should_create_account_and_register_allocation_to_committee() {
+        // Given
+        final var currency = Currencies.USD;
+        final var sponsorId = SponsorId.random();
+        final var sponsorAccount = new Account(PositiveMoney.of(100L, currency));
+        final var committeeId = CommitteeId.random();
+        final var committeeAccount = new Account(currency);
+
+        when(currencyStorage.get(currency.id())).thenReturn(Optional.of(currency));
+        when(sponsorAccountProvider.get(sponsorId, currency)).thenReturn(Optional.of(sponsorAccount));
+        when(committeeAccountProvider.get(committeeId, currency)).thenReturn(Optional.empty());
+        when(committeeAccountProvider.create(committeeId, currency)).thenReturn(committeeAccount);
+
+        // When
+        sponsorAccountingService.allocate(sponsorId, committeeId, PositiveAmount.of(10L), currency.id());
+
+        // Then
+        assertThat(sponsorAccount.balance()).isEqualTo(Money.of(90L, currency));
+        assertThat(committeeAccount.balance()).isEqualTo(Money.of(10L, currency));
+        assertThat(committeeAccount.balanceFrom(sponsorAccount.getId())).isEqualTo(Money.of(10L, currency));
+    }
 }

--- a/accounting-domain/src/test/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingServiceTest.java
+++ b/accounting-domain/src/test/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingServiceTest.java
@@ -1,0 +1,47 @@
+package onlydust.com.marketplace.accounting.domain;
+
+import onlydust.com.marketplace.accounting.domain.model.*;
+import onlydust.com.marketplace.accounting.domain.port.out.CurrencyStorage;
+import onlydust.com.marketplace.accounting.domain.stubs.Currencies;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class SponsorAccountingServiceTest {
+    final SponsorAccountProvider sponsorAccountProvider = mock(SponsorAccountProvider.class);
+    final CurrencyStorage currencyStorage = mock(CurrencyStorage.class);
+    final SponsorAccountingService sponsorAccountingService = new SponsorAccountingService(sponsorAccountProvider, currencyStorage);
+
+    @BeforeEach
+    void setUp() {
+        reset(sponsorAccountProvider, currencyStorage);
+    }
+
+    /*
+     * Given a newly created sponsor
+     * When I transfer money to OnlyDust
+     * Then A new account is created for me and the transfer is registered on it
+     */
+    @Test
+    void should_create_account_and_register_transfer() {
+        // Given
+        final var sponsorId = SponsorId.random();
+        final var currency = Currencies.USD;
+        final var account = new Account(currency);
+
+        when(currencyStorage.get(currency.id())).thenReturn(Optional.of(currency));
+        when(sponsorAccountProvider.get(sponsorId, currency)).thenReturn(Optional.empty());
+        when(sponsorAccountProvider.create(sponsorId, currency)).thenReturn(account);
+
+        // When
+        sponsorAccountingService.receiveFrom(sponsorId, PositiveAmount.of(10L), currency.id());
+
+        // Then
+        assertThat(account.balance()).isEqualTo(Money.of(10L, currency));
+    }
+}

--- a/accounting-domain/src/test/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingServiceTest.java
+++ b/accounting-domain/src/test/java/onlydust/com/marketplace/accounting/domain/SponsorAccountingServiceTest.java
@@ -155,6 +155,28 @@ public class SponsorAccountingServiceTest {
 
     /*
      * Given a sponsor with an account
+     * When I refund money from OnlyDust of more than I sent
+     * Then The refund is rejected
+     */
+    @Test
+    void should_reject_refund_when_not_enough_received() {
+        // Given
+        final var sponsorId = SponsorId.random();
+        final var currency = Currencies.USD;
+        final var account = new Account(PositiveMoney.of(100L, currency));
+
+        when(currencyStorage.get(currency.id())).thenReturn(Optional.of(currency));
+        when(sponsorAccountProvider.get(sponsorId, currency)).thenReturn(Optional.of(account));
+
+        // When
+        assertThatThrownBy(() -> sponsorAccountingService.refundTo(sponsorId, PositiveAmount.of(110L), currency.id()))
+                // Then
+                .isInstanceOf(OnlyDustException.class)
+                .hasMessage("Insufficient funds");
+    }
+
+    /*
+     * Given a sponsor with an account
      * When I allocate money to a committee
      * Then The transfer is registered from my account to the committee account
      */


### PR DESCRIPTION
- receive money from new sponsor
- receive money from existing sponsor
- refund money to sponsor
- reject refund if no account found
- handled unknown currency
- refactor
- allocate funds to committee
- create committee account upon transfer
- handle currency not found
- unallocate funds from committee
- handle currency not found
- handle account not found
- handle insufficient funds
