### PR TITLE
Proposal to use JsonTypeInfo.Id.NAME instead of JsonTypeInfo.Id.CLASS so it is easier to maintain and less error-prone

### DIFF
--- a/accounting-domain/src/main/java/onlydust/com/marketplace/accounting/domain/events/InvoiceUploaded.java
+++ b/accounting-domain/src/main/java/onlydust/com/marketplace/accounting/domain/events/InvoiceUploaded.java
@@ -9,12 +9,14 @@ import lombok.experimental.Accessors;
 import onlydust.com.marketplace.accounting.domain.model.Invoice;
 import onlydust.com.marketplace.accounting.domain.model.billingprofile.BillingProfile;
 import onlydust.com.marketplace.kernel.model.Event;
+import onlydust.com.marketplace.kernel.model.EventType;
 
 @Value
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 @Accessors(fluent = true)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@EventType("InvoiceUploaded")
 public class InvoiceUploaded extends Event {
     @NonNull BillingProfile.Id billingProfileId;
     @NonNull Invoice.Id invoiceId;

--- a/application/sumsub-webhook-adapter/src/main/java/onlydust/com/marketplace/api/sumsub/webhook/adapter/dto/SumsubWebhookEventDTO.java
+++ b/application/sumsub-webhook-adapter/src/main/java/onlydust/com/marketplace/api/sumsub/webhook/adapter/dto/SumsubWebhookEventDTO.java
@@ -4,11 +4,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import onlydust.com.marketplace.kernel.model.Event;
+import onlydust.com.marketplace.kernel.model.EventType;
 
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
+@EventType("SumsubWebhookEventDTO")
 public class SumsubWebhookEventDTO extends Event {
     @JsonProperty("applicantId")
     String applicantId;

--- a/infrastructure/postgres-adapter/src/main/java/onlydust/com/marketplace/api/postgres/adapter/entity/write/EventEntity.java
+++ b/infrastructure/postgres-adapter/src/main/java/onlydust/com/marketplace/api/postgres/adapter/entity/write/EventEntity.java
@@ -1,6 +1,7 @@
 package onlydust.com.marketplace.api.postgres.adapter.entity.write;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import io.hypersistence.utils.hibernate.type.basic.PostgreSQLEnumType;
 import lombok.AllArgsConstructor;
@@ -8,6 +9,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import onlydust.com.marketplace.kernel.model.Event;
+import onlydust.com.marketplace.kernel.model.EventIdResolver;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
@@ -62,7 +64,8 @@ public abstract class EventEntity {
     @NoArgsConstructor
     public static class Payload implements Serializable {
 
-        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "$typeId")
+        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "@type")
+        @JsonTypeIdResolver(EventIdResolver.class)
         private Event event;
     }
 

--- a/infrastructure/postgres-adapter/src/main/java/onlydust/com/marketplace/api/postgres/adapter/entity/write/EventEntity.java
+++ b/infrastructure/postgres-adapter/src/main/java/onlydust/com/marketplace/api/postgres/adapter/entity/write/EventEntity.java
@@ -62,7 +62,7 @@ public abstract class EventEntity {
     @NoArgsConstructor
     public static class Payload implements Serializable {
 
-        @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "className")
+        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "$typeId")
         private Event event;
     }
 

--- a/infrastructure/postgres-adapter/src/main/resources/db/changelog/changelogs/00000060_improve_outbox_events.sql
+++ b/infrastructure/postgres-adapter/src/main/resources/db/changelog/changelogs/00000060_improve_outbox_events.sql
@@ -5,7 +5,7 @@ WHERE payload ? 'notification';
 
 UPDATE indexer_outbox_events
 SET payload = jsonb_set(payload #- '{event,className}',
-                        '{event,$typeId}',
+                        '{event,@type}',
                         ('"' || split_part(payload #>> '{event,className}', '.', -1) || '"')::jsonb)
 WHERE payload #> '{event}' ? 'className';
 
@@ -16,7 +16,7 @@ WHERE payload ? 'notification';
 
 UPDATE notification_outbox_events
 SET payload = jsonb_set(payload #- '{event,className}',
-                        '{event,$typeId}',
+                        '{event,@type}',
                         ('"' || split_part(payload #>> '{event,className}', '.', -1) || '"')::jsonb)
 WHERE payload #> '{event}' ? 'className';
 
@@ -28,7 +28,7 @@ WHERE payload ? 'notification';
 
 UPDATE tracking_outbox_events
 SET payload = jsonb_set(payload #- '{event,className}',
-                        '{event,$typeId}',
+                        '{event,@type}',
                         ('"' || split_part(payload #>> '{event,className}', '.', -1) || '"')::jsonb)
 WHERE payload #> '{event}' ? 'className';
 
@@ -40,6 +40,6 @@ WHERE payload ? 'notification';
 
 UPDATE user_verification_outbox_events
 SET payload = jsonb_set(payload #- '{event,className}',
-                        '{event,$typeId}',
+                        '{event,@type}',
                         ('"' || split_part(payload #>> '{event,className}', '.', -1) || '"')::jsonb)
 WHERE payload #> '{event}' ? 'className';

--- a/infrastructure/postgres-adapter/src/main/resources/db/changelog/changelogs/00000060_improve_outbox_events.sql
+++ b/infrastructure/postgres-adapter/src/main/resources/db/changelog/changelogs/00000060_improve_outbox_events.sql
@@ -1,0 +1,45 @@
+-- indexer_outbox_events
+UPDATE indexer_outbox_events
+SET payload = jsonb_set(payload #- '{notification}', '{event}', payload #> '{notification}')
+WHERE payload ? 'notification';
+
+UPDATE indexer_outbox_events
+SET payload = jsonb_set(payload #- '{event,className}',
+                        '{event,$typeId}',
+                        ('"' || split_part(payload #>> '{event,className}', '.', -1) || '"')::jsonb)
+WHERE payload #> '{event}' ? 'className';
+
+-- notification_outbox_events
+UPDATE notification_outbox_events
+SET payload = jsonb_set(payload #- '{notification}', '{event}', payload #> '{notification}')
+WHERE payload ? 'notification';
+
+UPDATE notification_outbox_events
+SET payload = jsonb_set(payload #- '{event,className}',
+                        '{event,$typeId}',
+                        ('"' || split_part(payload #>> '{event,className}', '.', -1) || '"')::jsonb)
+WHERE payload #> '{event}' ? 'className';
+
+
+-- tracking_outbox_events
+UPDATE tracking_outbox_events
+SET payload = jsonb_set(payload #- '{notification}', '{event}', payload #> '{notification}')
+WHERE payload ? 'notification';
+
+UPDATE tracking_outbox_events
+SET payload = jsonb_set(payload #- '{event,className}',
+                        '{event,$typeId}',
+                        ('"' || split_part(payload #>> '{event,className}', '.', -1) || '"')::jsonb)
+WHERE payload #> '{event}' ? 'className';
+
+
+-- user_verification_outbox_events
+UPDATE user_verification_outbox_events
+SET payload = jsonb_set(payload #- '{notification}', '{event}', payload #> '{notification}')
+WHERE payload ? 'notification';
+
+UPDATE user_verification_outbox_events
+SET payload = jsonb_set(payload #- '{event,className}',
+                        '{event,$typeId}',
+                        ('"' || split_part(payload #>> '{event,className}', '.', -1) || '"')::jsonb)
+WHERE payload #> '{event}' ? 'className';

--- a/kernel/pom.xml
+++ b/kernel/pom.xml
@@ -25,6 +25,10 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/kernel/src/main/java/onlydust/com/marketplace/kernel/model/EventIdResolver.java
+++ b/kernel/src/main/java/onlydust/com/marketplace/kernel/model/EventIdResolver.java
@@ -1,0 +1,59 @@
+package onlydust.com.marketplace.kernel.model;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
+import org.reflections.Reflections;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class EventIdResolver extends TypeIdResolverBase {
+
+    private JavaType baseType;
+    private final Map<String, Class<?>> typeMap = new HashMap<>();
+
+    @Override
+    public void init(JavaType baseType) {
+        this.baseType = baseType;
+
+        record EventAnnotatedClass(Class<?> aClass, EventType eventType) {
+        }
+
+        final var reflections = new Reflections("onlydust.com");
+        reflections.getSubTypesOf(baseType.getRawClass()).stream()
+                .map(aClass -> new EventAnnotatedClass(aClass, aClass.getAnnotation(EventType.class)))
+                .filter(annotatedClass -> Objects.nonNull(annotatedClass.eventType()))
+                .forEach(annotatedClass -> typeMap.put(annotatedClass.eventType().value(), annotatedClass.aClass()));
+    }
+
+    @Override
+    public String idFromValue(Object o) {
+        return idFromValueAndType(o, o.getClass());
+    }
+
+    @Override
+    public String idFromValueAndType(Object o, Class<?> aClass) {
+        final var eventType = aClass.getAnnotation(EventType.class);
+        if (eventType == null || !typeMap.containsKey(eventType.value())) {
+            throw new IllegalArgumentException("Class " + aClass.getName() + " is not annotated with EventType or is not a subtype of " + baseType.getRawClass().getName());
+        }
+        return aClass.getAnnotation(EventType.class).value();
+    }
+
+    @Override
+    public JavaType typeFromId(DatabindContext context, String id) {
+        final var subType = typeMap.get(id);
+        if (subType == null) {
+            throw new IllegalArgumentException("No class annotated with @EventType(\"%s\") could be found".formatted(id));
+        }
+        return context.constructSpecializedType(baseType, subType);
+    }
+
+    @Override
+    public JsonTypeInfo.Id getMechanism() {
+        return JsonTypeInfo.Id.NAME;
+    }
+}

--- a/kernel/src/main/java/onlydust/com/marketplace/kernel/model/EventType.java
+++ b/kernel/src/main/java/onlydust/com/marketplace/kernel/model/EventType.java
@@ -1,0 +1,12 @@
+package onlydust.com.marketplace.kernel.model;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface EventType {
+    String value();
+}

--- a/kernel/src/test/java/onlydust/com/marketplace/kernel/model/EventIdResolverTest.java
+++ b/kernel/src/test/java/onlydust/com/marketplace/kernel/model/EventIdResolverTest.java
@@ -1,0 +1,60 @@
+package onlydust.com.marketplace.kernel.model;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EventIdResolverTest {
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class TestEventContainer implements Serializable {
+        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "@type")
+        @JsonTypeIdResolver(EventIdResolver.class)
+        private TestEvent testEvent;
+    }
+
+    public static abstract class TestEvent {
+    }
+
+    @EventType("A")
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class SubATestEvent extends TestEvent {
+        public String foo;
+    }
+
+    @EventType("B")
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class SubBTestEvent extends TestEvent {
+        public String bar;
+    }
+
+    @Test
+    void should_serialize_with_type_id() throws JsonProcessingException {
+        final var testContainer = new TestEventContainer(new SubATestEvent("yolo"));
+        final var mapper = new ObjectMapper();
+        final var serialized = mapper.writeValueAsString(testContainer);
+
+        assertThat(serialized).isEqualTo("{\"testEvent\":{\"@type\":\"A\",\"foo\":\"yolo\"}}");
+    }
+
+    @Test
+    void should_deserialize_with_type_id() throws JsonProcessingException {
+        final var mapper = new ObjectMapper();
+        final var deserialized = mapper.readValue("{\"testEvent\":{\"@type\":\"B\",\"bar\":\"yolo\"}}", TestEventContainer.class);
+
+        assertThat(deserialized).isNotNull();
+        assertThat(deserialized.testEvent).isInstanceOf(SubBTestEvent.class);
+        assertThat(((SubBTestEvent) deserialized.testEvent).bar).isEqualTo("yolo");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,11 @@
                 <artifactId>slack-api-client</artifactId>
                 <version>${slack-api-client.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.reflections</groupId>
+                <artifactId>reflections</artifactId>
+                <version>0.10.2</version>
+            </dependency>
 
 
             <!-- Test -->

--- a/project-domain/src/main/java/onlydust/com/marketplace/project/domain/model/notification/BillingProfileUpdated.java
+++ b/project-domain/src/main/java/onlydust/com/marketplace/project/domain/model/notification/BillingProfileUpdated.java
@@ -3,6 +3,7 @@ package onlydust.com.marketplace.project.domain.model.notification;
 import lombok.*;
 import onlydust.com.marketplace.kernel.jobs.OutboxSkippingException;
 import onlydust.com.marketplace.kernel.model.Event;
+import onlydust.com.marketplace.kernel.model.EventType;
 import onlydust.com.marketplace.project.domain.model.OldBillingProfileType;
 import onlydust.com.marketplace.project.domain.model.OldVerificationStatus;
 
@@ -15,6 +16,7 @@ import static java.util.Objects.nonNull;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
+@EventType("BillingProfileUpdated")
 public class BillingProfileUpdated extends Event {
     UUID billingProfileId;
     OldBillingProfileType type;

--- a/project-domain/src/main/java/onlydust/com/marketplace/project/domain/model/notification/ProjectCreated.java
+++ b/project-domain/src/main/java/onlydust/com/marketplace/project/domain/model/notification/ProjectCreated.java
@@ -1,5 +1,6 @@
 package onlydust.com.marketplace.project.domain.model.notification;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -13,6 +14,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
+@JsonTypeName("ProjectCreated")
 public class ProjectCreated extends Event {
     UUID projectId;
     Date createdAt;

--- a/project-domain/src/main/java/onlydust/com/marketplace/project/domain/model/notification/ProjectCreated.java
+++ b/project-domain/src/main/java/onlydust/com/marketplace/project/domain/model/notification/ProjectCreated.java
@@ -1,11 +1,11 @@
 package onlydust.com.marketplace.project.domain.model.notification;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import onlydust.com.marketplace.kernel.model.Event;
+import onlydust.com.marketplace.kernel.model.EventType;
 
 import java.util.Date;
 import java.util.UUID;
@@ -14,7 +14,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
-@JsonTypeName("ProjectCreated")
+@EventType("ProjectCreated")
 public class ProjectCreated extends Event {
     UUID projectId;
     Date createdAt;

--- a/project-domain/src/main/java/onlydust/com/marketplace/project/domain/model/notification/ProjectLeaderAssigned.java
+++ b/project-domain/src/main/java/onlydust/com/marketplace/project/domain/model/notification/ProjectLeaderAssigned.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import onlydust.com.marketplace.kernel.model.Event;
+import onlydust.com.marketplace.kernel.model.EventType;
 
 import java.util.Date;
 import java.util.UUID;
@@ -13,6 +14,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
+@EventType("ProjectLeaderAssigned")
 public class ProjectLeaderAssigned extends Event {
     UUID projectId;
     UUID leaderId;

--- a/project-domain/src/main/java/onlydust/com/marketplace/project/domain/model/notification/ProjectLeaderInvitationCancelled.java
+++ b/project-domain/src/main/java/onlydust/com/marketplace/project/domain/model/notification/ProjectLeaderInvitationCancelled.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import onlydust.com.marketplace.kernel.model.Event;
+import onlydust.com.marketplace.kernel.model.EventType;
 
 import java.util.Date;
 import java.util.UUID;
@@ -13,6 +14,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
+@EventType("ProjectLeaderInvitationCancelled")
 public class ProjectLeaderInvitationCancelled extends Event {
     UUID projectId;
     Long githubUserId;

--- a/project-domain/src/main/java/onlydust/com/marketplace/project/domain/model/notification/ProjectLeaderInvited.java
+++ b/project-domain/src/main/java/onlydust/com/marketplace/project/domain/model/notification/ProjectLeaderInvited.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import onlydust.com.marketplace.kernel.model.Event;
+import onlydust.com.marketplace.kernel.model.EventType;
 
 import java.util.Date;
 import java.util.UUID;
@@ -13,6 +14,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
+@EventType("ProjectLeaderInvited")
 public class ProjectLeaderInvited extends Event {
     UUID projectId;
     Long githubUserId;

--- a/project-domain/src/main/java/onlydust/com/marketplace/project/domain/model/notification/ProjectLeaderUnassigned.java
+++ b/project-domain/src/main/java/onlydust/com/marketplace/project/domain/model/notification/ProjectLeaderUnassigned.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import onlydust.com.marketplace.kernel.model.Event;
+import onlydust.com.marketplace.kernel.model.EventType;
 
 import java.util.Date;
 import java.util.UUID;
@@ -13,6 +14,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
+@EventType("ProjectLeaderUnassigned")
 public class ProjectLeaderUnassigned extends Event {
     UUID projectId;
     UUID leaderId;

--- a/project-domain/src/main/java/onlydust/com/marketplace/project/domain/model/notification/ProjectLinkedReposChanged.java
+++ b/project-domain/src/main/java/onlydust/com/marketplace/project/domain/model/notification/ProjectLinkedReposChanged.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import onlydust.com.marketplace.kernel.model.Event;
+import onlydust.com.marketplace.kernel.model.EventType;
 
 import java.util.Set;
 import java.util.UUID;
@@ -13,6 +14,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
+@EventType("ProjectLinkedReposChanged")
 public class ProjectLinkedReposChanged extends Event {
     UUID projectId;
     java.util.Set<Long> linkedRepoIds;

--- a/project-domain/src/main/java/onlydust/com/marketplace/project/domain/model/notification/ProjectUpdated.java
+++ b/project-domain/src/main/java/onlydust/com/marketplace/project/domain/model/notification/ProjectUpdated.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import onlydust.com.marketplace.kernel.model.Event;
+import onlydust.com.marketplace.kernel.model.EventType;
 
 import java.util.Date;
 import java.util.UUID;
@@ -13,6 +14,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
+@EventType("ProjectUpdated")
 public class ProjectUpdated extends Event {
     UUID projectId;
     Date updatedAt;

--- a/project-domain/src/main/java/onlydust/com/marketplace/project/domain/model/notification/UserAppliedOnProject.java
+++ b/project-domain/src/main/java/onlydust/com/marketplace/project/domain/model/notification/UserAppliedOnProject.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import onlydust.com.marketplace.kernel.model.Event;
+import onlydust.com.marketplace.kernel.model.EventType;
 
 import java.util.Date;
 import java.util.UUID;
@@ -13,6 +14,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
+@EventType("UserAppliedOnProject")
 public class UserAppliedOnProject extends Event {
     UUID applicationId;
     UUID projectId;

--- a/project-domain/src/main/java/onlydust/com/marketplace/project/domain/model/notification/UserSignedUp.java
+++ b/project-domain/src/main/java/onlydust/com/marketplace/project/domain/model/notification/UserSignedUp.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import onlydust.com.marketplace.kernel.model.Event;
+import onlydust.com.marketplace.kernel.model.EventType;
 
 import java.util.Date;
 import java.util.UUID;
@@ -13,6 +14,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = true)
+@EventType("UserSignedUp")
 public class UserSignedUp extends Event {
     UUID userId;
     Long githubUserId;


### PR DESCRIPTION
Add custom annotation and custom Type resolver to avoid declaring all sub types with @JsonSubTypes