### PR TITLE
BREAKING CHANGE: add query param to include (or not) contributions from private projects in GET /api/v2/users/{githubId}/contributions

### DIFF
--- a/bootstrap/src/main/java/onlydust/com/marketplace/api/bootstrap/configuration/RestApiConfiguration.java
+++ b/bootstrap/src/main/java/onlydust/com/marketplace/api/bootstrap/configuration/RestApiConfiguration.java
@@ -38,8 +38,9 @@ public class RestApiConfiguration {
     }
 
     @Bean
-    public UsersRestApi usersRestApi(final ContributorFacadePort contributorFacadePort) {
-        return new UsersRestApi(contributorFacadePort);
+    public UsersRestApi usersRestApi(final AuthenticatedAppUserService authenticatedAppUserService,
+                                     final ContributorFacadePort contributorFacadePort) {
+        return new UsersRestApi(authenticatedAppUserService, contributorFacadePort);
     }
 
     @Bean
@@ -87,7 +88,7 @@ public class RestApiConfiguration {
 
     @Bean
     public CommitteeRestApi committeeRestApi(final AuthenticatedAppUserService authenticatedAppUserService,
-                                             final CommitteeFacadePort committeeFacadePort){
+                                             final CommitteeFacadePort committeeFacadePort) {
         return new CommitteeRestApi(authenticatedAppUserService, committeeFacadePort);
     }
 }

--- a/bootstrap/src/test/java/onlydust/com/marketplace/api/bootstrap/it/api/UserContributionsApiIT.java
+++ b/bootstrap/src/test/java/onlydust/com/marketplace/api/bootstrap/it/api/UserContributionsApiIT.java
@@ -22,13 +22,13 @@ public class UserContributionsApiIT extends AbstractMarketplaceApiIT {
     private ImageStoragePort imageStoragePort;
 
     @Test
-    void should_get_my_contributions() {
+    void should_get_my_contributions_including_private_projects() {
         // Given
         final var user = userAuthHelper.authenticateAnthony();
 
         // When
         client.get()
-                .uri(getApiURI(USERS_GET_CONTRIBUTIONS.formatted(user.user().getGithubUserId()), Map.of("pageSize", "3")))
+                .uri(getApiURI(USERS_GET_CONTRIBUTIONS.formatted(user.user().getGithubUserId()), Map.of("pageSize", "3", "includePrivateProjects", "true")))
                 .header("Authorization", BEARER_PREFIX + user.jwt())
                 // Then
                 .exchange()
@@ -178,6 +178,162 @@ public class UserContributionsApiIT extends AbstractMarketplaceApiIT {
     }
 
     @Test
+    void should_get_my_contributions_without_private_projects() {
+        // Given
+        final var user = userAuthHelper.authenticateAnthony();
+
+        // When
+        client.get()
+                .uri(getApiURI(USERS_GET_CONTRIBUTIONS.formatted(user.user().getGithubUserId()), Map.of("pageSize", "3")))
+                .header("Authorization", BEARER_PREFIX + user.jwt())
+                // Then
+                .exchange()
+                .expectStatus()
+                .isEqualTo(HttpStatus.PARTIAL_CONTENT)
+                .expectBody()
+                .consumeWith(System.out::println)
+                .json("""
+                        {
+                          "contributions": [
+                            {
+                              "type": "PULL_REQUEST",
+                              "repo": {
+                                "id": 480776993,
+                                "owner": "onlydustxyz",
+                                "name": "starklings",
+                                "description": null,
+                                "htmlUrl": "https://github.com/onlydustxyz/starklings"
+                              },
+                              "githubAuthor": {
+                                "githubUserId": 43467246,
+                                "login": "AnthonyBuisset",
+                                "avatarUrl": "https://onlydust-app-images.s3.eu-west-1.amazonaws.com/11725380531262934574.webp"
+                              },
+                              "githubNumber": 2,
+                              "githubStatus": "MERGED",
+                              "githubTitle": "DUST token creation",
+                              "githubHtmlUrl": "https://github.com/onlydustxyz/starklings/pull/2",
+                              "githubBody": "ERC721 based\\r\\ncan be minted and burned\\r\\non-chain metadata:\\r\\n* Space size\\r\\n* position (x, y)\\r\\n* direction (x, y)\\r\\n\\r\\nCan move and will bounce in case it hurts one of the border/corner of the space\\r\\n\\r\\nSome nice features added:\\r\\n* batch minting (with user defined position/direction)\\r\\n* random minting (on the edge of the board game)\\r\\n* random batch minting\\r\\n* optimization of storage",
+                              "githubCodeReviewOutcome": null,
+                              "id": "6d3bac610f1f9e983b179478916eefcd39583dd7ca869ec15529c66539ff9045",
+                              "createdAt": "2022-04-12T16:56:44Z",
+                              "completedAt": "2022-04-13T09:00:48Z",
+                              "lastUpdatedAt": "2022-04-13T09:00:48Z",
+                              "status": "COMPLETED",
+                              "githubPullRequestReviewState": "PENDING_REVIEWER",
+                              "rewardIds": [],
+                              "project": {
+                                "id": "00490be6-2c03-4720-993b-aea3e07edd81",
+                                "slug": "zama",
+                                "name": "Zama",
+                                "shortDescription": "A super description for Zama",
+                                "logoUrl": "https://dl.airtable.com/.attachments/f776b6ea66adbe46d86adaea58626118/610d50f6/15TqNyRwTMGoVeAX2u1M",
+                                "visibility": "PUBLIC"
+                              },
+                              "contributor": {
+                                "githubUserId": 43467246,
+                                "login": "AnthonyBuisset",
+                                "avatarUrl": "https://onlydust-app-images.s3.eu-west-1.amazonaws.com/11725380531262934574.webp",
+                                "isRegistered": true
+                              },
+                              "links": []
+                            },
+                            {
+                              "type": "PULL_REQUEST",
+                              "repo": {
+                                "id": 480776993,
+                                "owner": "onlydustxyz",
+                                "name": "starklings",
+                                "description": null,
+                                "htmlUrl": "https://github.com/onlydustxyz/starklings"
+                              },
+                              "githubAuthor": {
+                                "githubUserId": 595505,
+                                "login": "ofux",
+                                "avatarUrl": "https://onlydust-app-images.s3.eu-west-1.amazonaws.com/5494259449694867225.webp"
+                              },
+                              "githubNumber": 1,
+                              "githubStatus": "DRAFT",
+                              "githubTitle": "feat: add common model",
+                              "githubHtmlUrl": "https://github.com/onlydustxyz/starklings/pull/1",
+                              "githubBody": "Note: if we use ERC20 instead of ERC721 to keep track of dust balance, then `token_id` must be removed from `Dust` struct.",
+                              "githubCodeReviewOutcome": null,
+                              "id": "7b076143d6844660494a112d2182017a367914577b14ed562250ef1751de6547",
+                              "createdAt": "2022-04-12T11:59:17Z",
+                              "completedAt": "2022-04-13T09:00:49Z",
+                              "lastUpdatedAt": "2022-04-13T09:00:49Z",
+                              "status": "COMPLETED",
+                              "githubPullRequestReviewState": "PENDING_REVIEWER",
+                              "rewardIds": [],
+                              "project": {
+                                "id": "00490be6-2c03-4720-993b-aea3e07edd81",
+                                "slug": "zama",
+                                "name": "Zama",
+                                "shortDescription": "A super description for Zama",
+                                "logoUrl": "https://dl.airtable.com/.attachments/f776b6ea66adbe46d86adaea58626118/610d50f6/15TqNyRwTMGoVeAX2u1M",
+                                "visibility": "PUBLIC"
+                              },
+                              "contributor": {
+                                "githubUserId": 43467246,
+                                "login": "AnthonyBuisset",
+                                "avatarUrl": "https://onlydust-app-images.s3.eu-west-1.amazonaws.com/11725380531262934574.webp",
+                                "isRegistered": true
+                              },
+                              "links": []
+                            },
+                            {
+                              "type": "PULL_REQUEST",
+                              "repo": {
+                                "id": 480776993,
+                                "owner": "onlydustxyz",
+                                "name": "starklings",
+                                "description": null,
+                                "htmlUrl": "https://github.com/onlydustxyz/starklings"
+                              },
+                              "githubAuthor": {
+                                "githubUserId": 595505,
+                                "login": "ofux",
+                                "avatarUrl": "https://onlydust-app-images.s3.eu-west-1.amazonaws.com/5494259449694867225.webp"
+                              },
+                              "githubNumber": 3,
+                              "githubStatus": "MERGED",
+                              "githubTitle": "Feature/space",
+                              "githubHtmlUrl": "https://github.com/onlydustxyz/starklings/pull/3",
+                              "githubBody": "Add a space contract that is in charge of processing game turns.\\r\\n\\r\\nAt each turn:\\r\\n- one dust is spawned\\r\\n- dust is moved on the grid\\r\\n- dust collisions are handled. When a collision occurs, one of the dust is burnt\\r\\n\\r\\nThe random generator is now in its own contract so we can mock it.\\r\\n\\r\\nThe TODOs can be found here: https://www.notion.so/onlydust/Workshop-TODO-9a67a936a5ca4180a3a23d7d94fecd61\\r\\n\\r\\n> Note: I just realised that we have different formatting between @AnthonyBuisset and me. I don't know why. This is quite annoying for tracking changes, so I apologise in advance.",
+                              "githubCodeReviewOutcome": null,
+                              "id": "5befa137a9ef4264834de24e223c7ee0b6fada1bb24ca3dc713496a96fba805b",
+                              "createdAt": "2022-04-13T15:42:14Z",
+                              "completedAt": "2022-04-13T16:01:10Z",
+                              "lastUpdatedAt": "2022-04-13T16:01:10Z",
+                              "status": "COMPLETED",
+                              "githubPullRequestReviewState": "APPROVED",
+                              "rewardIds": [],
+                              "project": {
+                                "id": "00490be6-2c03-4720-993b-aea3e07edd81",
+                                "slug": "zama",
+                                "name": "Zama",
+                                "shortDescription": "A super description for Zama",
+                                "logoUrl": "https://dl.airtable.com/.attachments/f776b6ea66adbe46d86adaea58626118/610d50f6/15TqNyRwTMGoVeAX2u1M",
+                                "visibility": "PUBLIC"
+                              },
+                              "contributor": {
+                                "githubUserId": 43467246,
+                                "login": "AnthonyBuisset",
+                                "avatarUrl": "https://onlydust-app-images.s3.eu-west-1.amazonaws.com/11725380531262934574.webp",
+                                "isRegistered": true
+                              },
+                              "links": []
+                            }
+                          ],
+                          "hasMore": true,
+                          "totalPageNumber": 1410,
+                          "totalItemNumber": 4230,
+                          "nextPageIndex": 1
+                        }
+                        """);
+    }
+
+    @Test
     void should_get_my_rewards_with_project_filter() {
         // Given
         final var user = userAuthHelper.authenticateAnthony();
@@ -209,7 +365,8 @@ public class UserContributionsApiIT extends AbstractMarketplaceApiIT {
         // When
         client.get()
                 .uri(getApiURI(USERS_GET_CONTRIBUTIONS.formatted(user.user().getGithubUserId()), Map.of(
-                        "ecosystems", "99b6c284-f9bb-4f89-8ce7-03771465ef8e,6ab7fa6c-c418-4997-9c5f-55fb021a8e5c")
+                        "ecosystems", "99b6c284-f9bb-4f89-8ce7-03771465ef8e,6ab7fa6c-c418-4997-9c5f-55fb021a8e5c",
+                        "includePrivateProjects", "true")
                 ))
                 .header("Authorization", BEARER_PREFIX + user.jwt())
                 // Then
@@ -301,7 +458,7 @@ public class UserContributionsApiIT extends AbstractMarketplaceApiIT {
         // When
         client.get()
                 .uri(getApiURI(USERS_GET_CONTRIBUTIONS.formatted(user.user().getGithubUserId()), Map.of(
-                        "types", "ISSUE")
+                        "types", "ISSUE", "includePrivateProjects", "true")
                 ))
                 .header("Authorization", BEARER_PREFIX + user.jwt())
                 // Then
@@ -327,6 +484,31 @@ public class UserContributionsApiIT extends AbstractMarketplaceApiIT {
         client.get()
                 .uri(getApiURI(USERS_GET_CONTRIBUTIONS.formatted(user.user().getGithubUserId()), Map.of(
                         "statuses", "IN_PROGRESS")
+                ))
+                .header("Authorization", BEARER_PREFIX + user.jwt())
+                // Then
+                .exchange()
+                .expectStatus()
+                .is2xxSuccessful()
+                .expectBody()
+                .jsonPath("$.contributions.length()").isEqualTo(1)
+                .jsonPath("$.contributions[0].status").isEqualTo("IN_PROGRESS")
+                .jsonPath("$.hasMore").isEqualTo(false)
+                .jsonPath("$.totalPageNumber").isEqualTo(1)
+                .jsonPath("$.totalItemNumber").isEqualTo(1)
+                .jsonPath("$.nextPageIndex").isEqualTo(0)
+        ;
+    }
+
+    @Test
+    void should_get_my_rewards_with_status_filter_and_includeing_private_projects() {
+        // Given
+        final var user = userAuthHelper.authenticateAnthony();
+
+        // When
+        client.get()
+                .uri(getApiURI(USERS_GET_CONTRIBUTIONS.formatted(user.user().getGithubUserId()), Map.of(
+                        "statuses", "IN_PROGRESS", "includePrivateProjects", "true")
                 ))
                 .header("Authorization", BEARER_PREFIX + user.jwt())
                 // Then

--- a/infrastructure/postgres-adapter/src/main/java/onlydust/com/marketplace/api/postgres/adapter/PostgresProjectAdapter.java
+++ b/infrastructure/postgres-adapter/src/main/java/onlydust/com/marketplace/api/postgres/adapter/PostgresProjectAdapter.java
@@ -145,6 +145,7 @@ public class PostgresProjectAdapter implements ProjectStoragePort {
                         List.of(),
                         new UUID[0],
                         new UUID[0],
+                        true,
                         null,
                         null,
                         Pageable.ofSize(1)).isEmpty(),

--- a/infrastructure/postgres-adapter/src/main/java/onlydust/com/marketplace/api/postgres/adapter/repository/ContributionViewEntityRepository.java
+++ b/infrastructure/postgres-adapter/src/main/java/onlydust/com/marketplace/api/postgres/adapter/repository/ContributionViewEntityRepository.java
@@ -175,6 +175,7 @@ public interface ContributionViewEntityRepository extends JpaRepository<Contribu
                 (COALESCE(:statuses) IS NULL OR CAST(c.status AS TEXT) IN (:statuses)) AND
                 (array_length(:ecosystemIds, 1) IS NULL OR contrib_ecosystems.ecosystem_ids && :ecosystemIds) AND
                 (array_length(:languageIds, 1) IS NULL OR contrib_languages.language_ids && :languageIds) AND
+                (p.visibility = 'PUBLIC' OR (:includePrivateProjects IS TRUE AND c.contributor_id = :callerGithubUserId)) AND
                 (:fromDate IS NULL OR coalesce(c.completed_at, c.created_at) >= to_date(cast(:fromDate as text), 'YYYY-MM-DD')) AND
                 (:toDate IS NULL OR coalesce(c.completed_at, c.created_at) < to_date(cast(:toDate as text), 'YYYY-MM-DD') + 1)
             """, nativeQuery = true)
@@ -186,6 +187,7 @@ public interface ContributionViewEntityRepository extends JpaRepository<Contribu
                                                    List<String> statuses,
                                                    UUID[] languageIds,
                                                    UUID[] ecosystemIds,
+                                                   boolean includePrivateProjects,
                                                    String fromDate,
                                                    String toDate,
                                                    Pageable pageable);

--- a/marketplace-api-contract/src/main/resources/marketplace-api-contract.yaml
+++ b/marketplace-api-contract/src/main/resources/marketplace-api-contract.yaml
@@ -977,6 +977,11 @@ paths:
             items:
               $ref: '#/components/schemas/EcosystemId'
         - in: query
+          name: includePrivateProjects
+          description: Include contributions in private projects
+          schema:
+            type: boolean
+        - in: query
           name: fromDate
           description: Contribution date filter
           schema:

--- a/project-domain/src/main/java/onlydust/com/marketplace/project/domain/port/input/ContributorFacadePort.java
+++ b/project-domain/src/main/java/onlydust/com/marketplace/project/domain/port/input/ContributorFacadePort.java
@@ -10,6 +10,7 @@ import onlydust.com.marketplace.project.domain.view.ContributionView;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -19,7 +20,7 @@ public interface ContributorFacadePort {
                                                                   int maxInternalContributorCountToReturn,
                                                                   boolean externalSearchOnly);
 
-    Page<ContributionView> contributions(Long contributorId,
+    Page<ContributionView> contributions(Optional<Long> callerGithubUserId,
                                          ContributionView.Filters filters,
                                          ContributionView.Sort sort,
                                          SortDirection direction,

--- a/project-domain/src/main/java/onlydust/com/marketplace/project/domain/port/output/ContributionStoragePort.java
+++ b/project-domain/src/main/java/onlydust/com/marketplace/project/domain/port/output/ContributionStoragePort.java
@@ -8,10 +8,11 @@ import onlydust.com.marketplace.project.domain.view.ContributionDetailsView;
 import onlydust.com.marketplace.project.domain.view.ContributionView;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface ContributionStoragePort {
-    Page<ContributionView> findContributions(Long contributorId,
+    Page<ContributionView> findContributions(Optional<Long> callerGithubUserId,
                                              ContributionView.Filters filters,
                                              ContributionView.Sort sort,
                                              SortDirection direction,

--- a/project-domain/src/main/java/onlydust/com/marketplace/project/domain/service/ContributorService.java
+++ b/project-domain/src/main/java/onlydust/com/marketplace/project/domain/service/ContributorService.java
@@ -12,10 +12,7 @@ import onlydust.com.marketplace.project.domain.port.output.*;
 import onlydust.com.marketplace.project.domain.view.ContributionView;
 import org.apache.commons.lang3.tuple.Pair;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 @AllArgsConstructor
 public class ContributorService implements ContributorFacadePort {
@@ -40,21 +37,21 @@ public class ContributorService implements ContributorFacadePort {
 
         final List<Contributor> externalContributors =
                 (externalSearchOnly || internalContributors.size() < maxInternalContributorCountToTriggerExternalSearch) &&
-                login != null && !login.isEmpty() ?
+                        login != null && !login.isEmpty() ?
                         getExternalContributors(login) : List.of();
 
         return Pair.of(internalContributors, externalContributors);
     }
 
     @Override
-    public Page<ContributionView> contributions(Long contributorId,
+    public Page<ContributionView> contributions(Optional<Long> callerGithubUserId,
                                                 ContributionView.Filters filters,
                                                 ContributionView.Sort sort,
                                                 SortDirection direction,
                                                 Integer page,
                                                 Integer pageSize) {
         return contributionStoragePort.findContributions(
-                contributorId, filters, sort, direction, page, pageSize);
+                callerGithubUserId, filters, sort, direction, page, pageSize);
     }
 
     @Override

--- a/project-domain/src/main/java/onlydust/com/marketplace/project/domain/service/ProjectService.java
+++ b/project-domain/src/main/java/onlydust/com/marketplace/project/domain/service/ProjectService.java
@@ -170,7 +170,7 @@ public class ProjectService implements ProjectFacadePort {
                 .anyMatch(userId -> projectLeadIds.stream()
                         .noneMatch(projectLeaderId -> projectLeaderId.equals(userId)))) {
             throw OnlyDustException.badRequest("Project leaders to keep must be a subset of current project " +
-                                               "leaders");
+                    "leaders");
         }
     }
 
@@ -275,7 +275,7 @@ public class ProjectService implements ProjectFacadePort {
                 return closedIssue;
             } else {
                 throw OnlyDustException.forbidden("Rewardable issue can only be created on repos linked to this " +
-                                                  "project");
+                        "project");
             }
         } else {
             throw OnlyDustException.forbidden("Only project leads can create rewardable issue on their projects");
@@ -323,7 +323,7 @@ public class ProjectService implements ProjectFacadePort {
         if (!permissionService.isUserProjectLead(projectId, caller.getId())) {
             throw OnlyDustException.forbidden("Only project leads can list project contributions");
         }
-        return contributionStoragePort.findContributions(caller.getGithubUserId(), filters, sort, direction, page,
+        return contributionStoragePort.findContributions(Optional.of(caller.getGithubUserId()), filters, sort, direction, page,
                 pageSize);
     }
 

--- a/project-domain/src/main/java/onlydust/com/marketplace/project/domain/view/ContributionView.java
+++ b/project-domain/src/main/java/onlydust/com/marketplace/project/domain/view/ContributionView.java
@@ -56,6 +56,7 @@ public class ContributionView {
         List<UUID> languages = List.of();
         @Builder.Default
         List<UUID> ecosystems = List.of();
+        Boolean includePrivateProjects;
         Date from;
         Date to;
     }

--- a/project-domain/src/test/java/onlydust/com/marketplace/project/domain/service/ProjectServiceTest.java
+++ b/project-domain/src/test/java/onlydust/com/marketplace/project/domain/service/ProjectServiceTest.java
@@ -670,7 +670,7 @@ public class ProjectServiceTest {
                 .totalPageNumber(1)
                 .build();
 
-        when(contributionStoragePort.findContributions(projectLead.getGithubUserId(), filters, sort, direction, page,
+        when(contributionStoragePort.findContributions(Optional.of(projectLead.getGithubUserId()), filters, sort, direction, page,
                 pageSize))
                 .thenReturn(expectedContributions);
 


### PR DESCRIPTION
By default, contributions from private projects won't be included anymore.

Hence, the front should add `includePrivateProjects=true` query param when calling `/api/v2/users/{githubId}/contributions` from "My contributions" page.