### PR TITLE
Implement GET ecosystem/contributors

### DIFF
--- a/bootstrap/src/main/java/onlydust/com/marketplace/api/bootstrap/configuration/WebSecurityConfiguration.java
+++ b/bootstrap/src/main/java/onlydust/com/marketplace/api/bootstrap/configuration/WebSecurityConfiguration.java
@@ -113,6 +113,8 @@ public class WebSecurityConfiguration {
                                 .requestMatchers(antMatcher(HttpMethod.GET, "/api/v1/github/**")).hasAuthority(USER.name())
                                 .requestMatchers(antMatcher(HttpMethod.GET, "/api/v1/technologies")).permitAll()
                                 .requestMatchers(antMatcher(HttpMethod.GET, "/api/v1/hackathons/**")).permitAll()
+                                .requestMatchers(antMatcher(HttpMethod.GET, "/api/v1/ecosystems/*/contributors")).permitAll()
+                                .requestMatchers(antMatcher(HttpMethod.GET, "/api/v1/ecosystems")).hasAuthority(USER.name())
                                 .requestMatchers(antMatcher(HttpMethod.GET, "/swagger-ui.html")).permitAll()
                                 .requestMatchers(antMatcher(HttpMethod.GET, "/v3/api-docs/**")).permitAll()
                                 .requestMatchers(antMatcher(HttpMethod.GET, "/swagger-ui/**")).permitAll()

--- a/bootstrap/src/test/java/onlydust/com/marketplace/api/bootstrap/it/api/AbstractMarketplaceApiIT.java
+++ b/bootstrap/src/test/java/onlydust/com/marketplace/api/bootstrap/it/api/AbstractMarketplaceApiIT.java
@@ -129,6 +129,7 @@ public class AbstractMarketplaceApiIT {
     protected static final String SUGGEST_NEW_TECHNOLOGY = "/api/v1/technologies";
     protected static final String GET_ALL_TECHNOLOGIES = "/api/v1/technologies";
     protected static final String GET_ALL_ECOSYSTEMS = "/api/v1/ecosystems";
+    protected static final String GET_ECOSYSTEM_CONTRIBUTORS = "/api/v1/ecosystems/%s/contributors";
     protected static final String BILLING_PROFILES_POST = "/api/v1/billing-profiles";
     protected static final String BILLING_PROFILES_GET_BY_ID = "/api/v1/billing-profiles/%s";
     protected static final String BILLING_PROFILES_DELETE_BY_ID = "/api/v1/billing-profiles/%s";

--- a/bootstrap/src/test/java/onlydust/com/marketplace/api/bootstrap/it/api/EcosystemsApiIT.java
+++ b/bootstrap/src/test/java/onlydust/com/marketplace/api/bootstrap/it/api/EcosystemsApiIT.java
@@ -90,4 +90,160 @@ public class EcosystemsApiIT extends AbstractMarketplaceApiIT {
                 .expectStatus()
                 .is4xxClientError();
     }
+
+    @Test
+    void should_return_ecosystem_contributors_by_contribution_count() {
+        // When
+        client.get()
+                .uri(getApiURI(GET_ECOSYSTEM_CONTRIBUTORS.formatted("Starknet"),
+                        Map.of("pageIndex", "0", "pageSize", "5")))
+                .exchange()
+                // Then
+                .expectStatus()
+                .is2xxSuccessful()
+                .expectBody()
+                .json("""
+                        {
+                          "totalPageNumber": 206,
+                          "totalItemNumber": 1027,
+                          "hasMore": true,
+                          "nextPageIndex": 1,
+                          "contributors": [
+                            {
+                              "githubUserId": 8019099,
+                              "login": "PeerRich",
+                              "avatarUrl": "https://avatars.githubusercontent.com/u/8019099?v=4",
+                              "dynamicRank": 1019,
+                              "globalRank": 20,
+                              "globalRankCategory": "A",
+                              "contributionCount": 2878,
+                              "rewardCount": 0,
+                              "totalEarnedUsd": 0
+                            },
+                            {
+                              "githubUserId": 3504472,
+                              "login": "zomars",
+                              "avatarUrl": "https://avatars.githubusercontent.com/u/3504472?v=4",
+                              "dynamicRank": 1018,
+                              "globalRank": 22,
+                              "globalRankCategory": "A",
+                              "contributionCount": 2280,
+                              "rewardCount": 0,
+                              "totalEarnedUsd": 0
+                            },
+                            {
+                              "githubUserId": 1046695,
+                              "login": "emrysal",
+                              "avatarUrl": "https://avatars.githubusercontent.com/u/1046695?v=4",
+                              "dynamicRank": 1017,
+                              "globalRank": 22,
+                              "globalRankCategory": "A",
+                              "contributionCount": 1733,
+                              "rewardCount": 0,
+                              "totalEarnedUsd": 0
+                            },
+                            {
+                              "githubUserId": 481465,
+                              "login": "frangio",
+                              "avatarUrl": "https://avatars.githubusercontent.com/u/481465?v=4",
+                              "dynamicRank": 1016,
+                              "globalRank": 19,
+                              "globalRankCategory": "A",
+                              "contributionCount": 1456,
+                              "rewardCount": 0,
+                              "totalEarnedUsd": 0
+                            },
+                            {
+                              "githubUserId": 1780212,
+                              "login": "hariombalhara",
+                              "avatarUrl": "https://avatars.githubusercontent.com/u/1780212?v=4",
+                              "dynamicRank": 1015,
+                              "globalRank": 26,
+                              "globalRankCategory": "A",
+                              "contributionCount": 1352,
+                              "rewardCount": 0,
+                              "totalEarnedUsd": 0
+                            }
+                          ]
+                        }
+                        """);
+    }
+
+    @Test
+    void should_return_ecosystem_contributors_by_total_earned() {
+        // When
+        client.get()
+                .uri(getApiURI(GET_ECOSYSTEM_CONTRIBUTORS.formatted("Starknet"),
+                        Map.of("pageIndex", "0", "pageSize", "5", "sort", "TOTAL_EARNED")))
+                .exchange()
+                // Then
+                .expectStatus()
+                .is2xxSuccessful()
+                .expectBody()
+                .json("""
+                        {
+                          "totalPageNumber": 206,
+                          "totalItemNumber": 1027,
+                          "hasMore": true,
+                          "nextPageIndex": 1,
+                          "contributors": [
+                            {
+                              "githubUserId": 8019099,
+                              "login": "PeerRich",
+                              "avatarUrl": "https://avatars.githubusercontent.com/u/8019099?v=4",
+                              "dynamicRank": 1019,
+                              "globalRank": 20,
+                              "globalRankCategory": "A",
+                              "contributionCount": 2878,
+                              "rewardCount": 0,
+                              "totalEarnedUsd": 0
+                            },
+                            {
+                              "githubUserId": 3504472,
+                              "login": "zomars",
+                              "avatarUrl": "https://avatars.githubusercontent.com/u/3504472?v=4",
+                              "dynamicRank": 1018,
+                              "globalRank": 22,
+                              "globalRankCategory": "A",
+                              "contributionCount": 2280,
+                              "rewardCount": 0,
+                              "totalEarnedUsd": 0
+                            },
+                            {
+                              "githubUserId": 1046695,
+                              "login": "emrysal",
+                              "avatarUrl": "https://avatars.githubusercontent.com/u/1046695?v=4",
+                              "dynamicRank": 1017,
+                              "globalRank": 22,
+                              "globalRankCategory": "A",
+                              "contributionCount": 1733,
+                              "rewardCount": 0,
+                              "totalEarnedUsd": 0
+                            },
+                            {
+                              "githubUserId": 481465,
+                              "login": "frangio",
+                              "avatarUrl": "https://avatars.githubusercontent.com/u/481465?v=4",
+                              "dynamicRank": 1016,
+                              "globalRank": 19,
+                              "globalRankCategory": "A",
+                              "contributionCount": 1456,
+                              "rewardCount": 0,
+                              "totalEarnedUsd": 0
+                            },
+                            {
+                              "githubUserId": 1780212,
+                              "login": "hariombalhara",
+                              "avatarUrl": "https://avatars.githubusercontent.com/u/1780212?v=4",
+                              "dynamicRank": 1015,
+                              "globalRank": 26,
+                              "globalRankCategory": "A",
+                              "contributionCount": 1352,
+                              "rewardCount": 0,
+                              "totalEarnedUsd": 0
+                            }
+                          ]
+                        }
+                        """);
+    }
 }

--- a/read-api/src/main/java/onlydust/com/marketplace/bff/read/ReadMarketplaceApiConfiguration.java
+++ b/read-api/src/main/java/onlydust/com/marketplace/bff/read/ReadMarketplaceApiConfiguration.java
@@ -55,7 +55,7 @@ public class ReadMarketplaceApiConfiguration {
     }
 
     @Bean
-    public ReadEcosystemsApiPostgresAdapter readEcosystemsApiPostgresAdapter() {
-        return new ReadEcosystemsApiPostgresAdapter();
+    public ReadEcosystemsApiPostgresAdapter readEcosystemsApiPostgresAdapter(final EcosystemContributorPageItemEntityRepository ecosystemContributorPageItemEntityRepository) {
+        return new ReadEcosystemsApiPostgresAdapter(ecosystemContributorPageItemEntityRepository);
     }
 }

--- a/read-api/src/main/java/onlydust/com/marketplace/bff/read/adapters/ReadEcosystemsApiPostgresAdapter.java
+++ b/read-api/src/main/java/onlydust/com/marketplace/bff/read/adapters/ReadEcosystemsApiPostgresAdapter.java
@@ -2,7 +2,11 @@ package onlydust.com.marketplace.bff.read.adapters;
 
 import lombok.AllArgsConstructor;
 import onlydust.com.marketplace.api.contract.ReadEcosystemsApi;
+import onlydust.com.marketplace.api.contract.model.EcosystemContributorsPage;
+import onlydust.com.marketplace.api.contract.model.EcosystemContributorsPageItemResponse;
 import onlydust.com.marketplace.api.contract.model.EcosystemProjectPageResponse;
+import onlydust.com.marketplace.bff.read.repositories.EcosystemContributorPageItemEntityRepository;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RestController;
@@ -11,8 +15,35 @@ import org.springframework.web.bind.annotation.RestController;
 @AllArgsConstructor
 @Transactional(readOnly = true)
 public class ReadEcosystemsApiPostgresAdapter implements ReadEcosystemsApi {
+    public static final String SORT_BY_TOTAL_EARNED = "TOTAL_EARNED";
+    final EcosystemContributorPageItemEntityRepository ecosystemContributorPageItemEntityRepository;
+
     @Override
     public ResponseEntity<EcosystemProjectPageResponse> getEcosystemProjects(String ecosystemSlug, Integer pageIndex, Integer pageSize, Boolean hasGoodFirstIssues) {
         return ReadEcosystemsApi.super.getEcosystemProjects(ecosystemSlug, pageIndex, pageSize, hasGoodFirstIssues);
+    }
+
+    @Override
+    public ResponseEntity<EcosystemContributorsPage> getEcosystemContributors(String ecosystemSlug, Integer pageIndex, Integer pageSize, String sort) {
+        final var contributors = SORT_BY_TOTAL_EARNED.equals(sort) ?
+                ecosystemContributorPageItemEntityRepository.findByEcosystemSlugOrderByTotalEarnedUsdDesc(ecosystemSlug, PageRequest.of(pageIndex, pageSize)) :
+                ecosystemContributorPageItemEntityRepository.findByEcosystemSlugOrderByContributionCountDesc(ecosystemSlug, PageRequest.of(pageIndex, pageSize));
+
+        return ResponseEntity.ok(new EcosystemContributorsPage()
+                .hasMore(contributors.hasNext())
+                .nextPageIndex(contributors.hasNext() ? pageIndex + 1 : null)
+                .totalItemNumber((int) contributors.getTotalElements())
+                .totalPageNumber(contributors.getTotalPages())
+                .contributors(contributors.stream().map(c -> new EcosystemContributorsPageItemResponse()
+                        .githubUserId(c.contributorId())
+                        .avatarUrl(c.avatarUrl())
+                        .login(c.login())
+                        .dynamicRank(SORT_BY_TOTAL_EARNED.equals(sort) ? c.totalEarnedUsdRank() : c.contributionCountRank())
+                        .globalRank(c.rank())
+                        .globalRankCategory(c.rankCategory())
+                        .contributionCount(c.contributionCount())
+                        .totalEarnedUsd(c.totalEarnedUsd())
+                        .rewardCount(c.rewardCount())
+                ).toList()));
     }
 }

--- a/read-api/src/main/java/onlydust/com/marketplace/bff/read/entities/user/EcosystemContributorPageItemEntity.java
+++ b/read-api/src/main/java/onlydust/com/marketplace/bff/read/entities/user/EcosystemContributorPageItemEntity.java
@@ -1,0 +1,54 @@
+package onlydust.com.marketplace.bff.read.entities.user;
+
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.Accessors;
+import onlydust.com.marketplace.api.contract.model.UserRankCategory;
+import org.hibernate.annotations.Immutable;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Entity
+@Value
+@ToString
+@Immutable
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@NoArgsConstructor(force = true)
+@Accessors(fluent = true)
+@IdClass(EcosystemContributorPageItemEntity.PrimaryKey.class)
+public class EcosystemContributorPageItemEntity {
+    @Id
+    @EqualsAndHashCode.Include
+    @NonNull
+    UUID ecosystemId;
+
+    @Id
+    @EqualsAndHashCode.Include
+    @NonNull
+    Long contributorId;
+
+    @NonNull String login;
+    @NonNull String avatarUrl;
+
+    @NonNull Integer rank;
+    @Enumerated(EnumType.STRING)
+    @NonNull
+    UserRankCategory rankCategory;
+    @NonNull Integer contributionCount;
+    @NonNull Integer contributionCountRank;
+    @NonNull Integer rewardCount;
+    @NonNull BigDecimal totalEarnedUsd;
+    @NonNull Integer totalEarnedUsdRank;
+
+    @Embeddable
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @EqualsAndHashCode
+    public static class PrimaryKey implements Serializable {
+        UUID ecosystemId;
+        Long contributorId;
+    }
+}

--- a/read-api/src/main/java/onlydust/com/marketplace/bff/read/repositories/EcosystemContributorPageItemEntityRepository.java
+++ b/read-api/src/main/java/onlydust/com/marketplace/bff/read/repositories/EcosystemContributorPageItemEntityRepository.java
@@ -1,0 +1,74 @@
+package onlydust.com.marketplace.bff.read.repositories;
+
+import onlydust.com.marketplace.bff.read.entities.user.EcosystemContributorPageItemEntity;
+import org.intellij.lang.annotations.Language;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+
+import java.util.UUID;
+
+public interface EcosystemContributorPageItemEntityRepository extends Repository<EcosystemContributorPageItemEntity, UUID> {
+    @Language("PostgreSQL")
+    String SELECT = """
+            select uer.ecosystem_id                       as ecosystem_id,
+                   uer.contributor_id                     as contributor_id,
+                   u.login                                as login,
+                   u.avatar_url                           as avatar_url,
+                   gur.rank                               as rank,
+                   case
+                        when gur.rank_percentile <= 0.02 then 'A'
+                        when gur.rank_percentile <= 0.04 then 'B'
+                        when gur.rank_percentile <= 0.06 then 'C'
+                        when gur.rank_percentile <= 0.08 then 'D'
+                        when gur.rank_percentile <= 0.10 then 'E'
+                        else 'F'
+                   end                                    as rank_category,
+                   stats.contribution_count               as contribution_count,
+                   rank() OVER (ORDER BY stats.contribution_count) as contribution_count_rank,
+                   coalesce(reward_stats.reward_count, 0) as reward_count,
+                   coalesce(reward_stats.usd_total, 0)    as total_earned_usd,
+                   rank() OVER (ORDER BY reward_stats.usd_total) as total_earned_usd_rank
+            from users_ecosystems_ranks uer
+                     join global_users_ranks gur on gur.github_user_id = uer.contributor_id
+                     join ecosystems eco on eco.id = uer.ecosystem_id
+                     join iam.all_users u on u.github_user_id = uer.contributor_id
+                     left join contributions_stats_per_ecosystem_per_user stats
+                          on stats.ecosystem_id = uer.ecosystem_id and 
+                             stats.contributor_id = uer.contributor_id
+                     left join received_rewards_stats_per_ecosystem_per_user reward_stats
+                               on reward_stats.ecosystem_id = uer.ecosystem_id and
+                                  reward_stats.recipient_id = uer.contributor_id
+            """;
+
+    // TODO: use real slug column
+    @Query(value = SELECT + """
+            where eco.name = :ecosystemSlug
+            order by stats.contribution_count desc
+            """,
+            countQuery = """
+                    select uer.ecosystem_id                     as ecosystem_id,
+                           uer.contributor_id                   as contributor_id
+                    from users_ecosystems_ranks uer
+                            join ecosystems eco on eco.id = uer.ecosystem_id
+                    where eco.name = :ecosystemSlug
+                    """,
+            nativeQuery = true)
+    Page<EcosystemContributorPageItemEntity> findByEcosystemSlugOrderByContributionCountDesc(String ecosystemSlug, Pageable pageable);
+
+    // TODO: use real slug column
+    @Query(value = SELECT + """
+            where eco.name = :ecosystemSlug
+            order by reward_stats.usd_total desc
+            """,
+            countQuery = """
+                    select uer.ecosystem_id                     as ecosystem_id,
+                           uer.contributor_id                   as contributor_id
+                    from users_ecosystems_ranks uer
+                            join ecosystems eco on eco.id = uer.ecosystem_id
+                    where eco.name = :ecosystemSlug
+                    """,
+            nativeQuery = true)
+    Page<EcosystemContributorPageItemEntity> findByEcosystemSlugOrderByTotalEarnedUsdDesc(String ecosystemSlug, Pageable pageable);
+}


### PR DESCRIPTION
For some unknown reason, the `projects_ecosystems` table contains corrupt data in the IT dump (ecosystem_ids do not belong to any ecosystem).

Therefore, the` contributions_stats_per_ecosystem_per_user` view has bad data too. As a result, I cannot test properly the GET /ecosystem/contributors when sorting by total_earn.