### PR TITLE
[B-2021] Clear both caches during logout

### DIFF
--- a/application/rest-api-adapter/src/main/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/AuthenticatedAppUserService.java
+++ b/application/rest-api-adapter/src/main/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/AuthenticatedAppUserService.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import onlydust.com.marketplace.api.rest.api.adapter.authentication.app.OnlyDustAppAuthentication;
 import onlydust.com.marketplace.kernel.exception.OnlyDustException;
 import onlydust.com.marketplace.project.domain.model.User;
-import onlydust.com.marketplace.project.domain.port.output.GithubAuthenticationPort;
+import onlydust.com.marketplace.project.domain.port.input.GithubUserPermissionsFacadePort;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 
@@ -19,7 +19,7 @@ import static onlydust.com.marketplace.kernel.exception.OnlyDustException.unauth
 public class AuthenticatedAppUserService {
 
     private final AuthenticationContext authenticationContext;
-    private final GithubAuthenticationPort githubAuthenticationPort;
+    private final GithubUserPermissionsFacadePort githubUserPermissionsFacadePort;
 
     /**
      * @return the authenticated user
@@ -57,6 +57,6 @@ public class AuthenticatedAppUserService {
     }
 
     public void logout() {
-        githubAuthenticationPort.logout(getAuthenticatedUser().getGithubUserId());
+        githubUserPermissionsFacadePort.logout(getAuthenticatedUser().getGithubUserId());
     }
 }

--- a/application/rest-api-adapter/src/test/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/AuthenticatedAppUserServiceTest.java
+++ b/application/rest-api-adapter/src/test/java/onlydust/com/marketplace/api/rest/api/adapter/authentication/AuthenticatedAppUserServiceTest.java
@@ -6,7 +6,7 @@ import onlydust.com.marketplace.api.rest.api.adapter.authentication.app.OnlyDust
 import onlydust.com.marketplace.kernel.exception.OnlyDustException;
 import onlydust.com.marketplace.kernel.model.AuthenticatedUser;
 import onlydust.com.marketplace.project.domain.model.User;
-import onlydust.com.marketplace.project.domain.port.output.GithubAuthenticationPort;
+import onlydust.com.marketplace.project.domain.port.input.GithubUserPermissionsFacadePort;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 
@@ -23,8 +23,8 @@ public class AuthenticatedAppUserServiceTest {
     private static final Faker faker = new Faker();
 
     final AuthenticationContext authenticationContext = mock(AuthenticationContext.class);
-    final GithubAuthenticationPort githubAuthenticationPort = mock(GithubAuthenticationPort.class);
-    final AuthenticatedAppUserService authenticatedAppUserService = new AuthenticatedAppUserService(authenticationContext, githubAuthenticationPort);
+    final GithubUserPermissionsFacadePort githubUserPermissionsFacadePort = mock(GithubUserPermissionsFacadePort.class);
+    final AuthenticatedAppUserService authenticatedAppUserService = new AuthenticatedAppUserService(authenticationContext, githubUserPermissionsFacadePort);
 
     final UUID userId = UUID.randomUUID();
     final long githubUserId = faker.number().randomNumber();
@@ -104,6 +104,6 @@ public class AuthenticatedAppUserServiceTest {
         authenticatedAppUserService.logout();
 
         // Then
-        verify(githubAuthenticationPort).logout(githubUserId);
+        verify(githubUserPermissionsFacadePort).logout(githubUserId);
     }
 }

--- a/bootstrap/src/main/java/onlydust/com/marketplace/api/configuration/WebSecurityConfiguration.java
+++ b/bootstrap/src/main/java/onlydust/com/marketplace/api/configuration/WebSecurityConfiguration.java
@@ -14,8 +14,8 @@ import onlydust.com.marketplace.api.rest.api.adapter.authentication.auth0.Auth0U
 import onlydust.com.marketplace.api.rest.api.adapter.authentication.backoffice.Auth0OnlyDustBackofficeAuthenticationService;
 import onlydust.com.marketplace.api.rest.api.adapter.authentication.token.QueryParamTokenAuthenticationFilter;
 import onlydust.com.marketplace.api.rest.api.adapter.authentication.token.QueryParamTokenAuthenticationService;
+import onlydust.com.marketplace.project.domain.port.input.GithubUserPermissionsFacadePort;
 import onlydust.com.marketplace.project.domain.port.input.UserFacadePort;
-import onlydust.com.marketplace.project.domain.port.output.GithubAuthenticationPort;
 import onlydust.com.marketplace.user.domain.port.input.BackofficeUserFacadePort;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -192,8 +192,8 @@ public class WebSecurityConfiguration {
 
     @Bean
     public AuthenticatedAppUserService authenticatedAppUserService(final AuthenticationContext authenticationContext,
-                                                                   final GithubAuthenticationPort githubAuthenticationPort) {
-        return new AuthenticatedAppUserService(authenticationContext, githubAuthenticationPort);
+                                                                   final GithubUserPermissionsFacadePort githubUserPermissionsFacadePort) {
+        return new AuthenticatedAppUserService(authenticationContext, githubUserPermissionsFacadePort);
     }
 
     @Bean

--- a/bootstrap/src/test/java/onlydust/com/marketplace/api/helper/Auth0ApiClientStub.java
+++ b/bootstrap/src/test/java/onlydust/com/marketplace/api/helper/Auth0ApiClientStub.java
@@ -20,8 +20,8 @@ public class Auth0ApiClientStub implements GithubAuthenticationPort {
     }
 
     @Override
-    public void logout(Long githubUserId) {
-        pats.remove(githubUserId);
+    public Optional<String> logout(Long githubUserId) {
+        return Optional.ofNullable(pats.remove(githubUserId));
     }
 
     public void withPat(Long githubUserId, String pat) {

--- a/infrastructure/auth0-api-client-adapter/src/main/java/onlydust/com/marketplace/api/auth0/api/client/adapter/Auth0ApiClientAdapter.java
+++ b/infrastructure/auth0-api-client-adapter/src/main/java/onlydust/com/marketplace/api/auth0/api/client/adapter/Auth0ApiClientAdapter.java
@@ -5,6 +5,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import io.netty.handler.codec.http.HttpMethod;
 import onlydust.com.marketplace.project.domain.port.output.GithubAuthenticationPort;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static java.net.URLEncoder.encode;
@@ -29,8 +30,8 @@ public class Auth0ApiClientAdapter implements GithubAuthenticationPort {
     }
 
     @Override
-    public void logout(Long githubUserId) {
-        patCache.invalidate(githubUserId);
+    public Optional<String> logout(Long githubUserId) {
+        return Optional.ofNullable(patCache.asMap().remove(githubUserId));
     }
 
     private String fetchGithubPersonalToken(Long githubUserId) {

--- a/infrastructure/github-api-adapter/src/main/java/onlydust/com/marketplace/api/github_api/adapters/GithubAuthenticationInfoAdapter.java
+++ b/infrastructure/github-api-adapter/src/main/java/onlydust/com/marketplace/api/github_api/adapters/GithubAuthenticationInfoAdapter.java
@@ -15,6 +15,11 @@ public class GithubAuthenticationInfoAdapter implements GithubAuthenticationInfo
     private final Map<String, Set<String>> scopesByToken = new HashMap<>();
 
     @Override
+    public void logout(String accessToken) {
+        scopesByToken.remove(accessToken);
+    }
+
+    @Override
     public Set<String> getAuthorizedScopes(String accessToken) {
         return scopesByToken.computeIfAbsent(accessToken, this::fetchAuthorizedScopes);
     }

--- a/project-domain/src/main/java/onlydust/com/marketplace/project/domain/port/input/GithubUserPermissionsFacadePort.java
+++ b/project-domain/src/main/java/onlydust/com/marketplace/project/domain/port/input/GithubUserPermissionsFacadePort.java
@@ -1,5 +1,7 @@
 package onlydust.com.marketplace.project.domain.port.input;
 
 public interface GithubUserPermissionsFacadePort {
+    void logout(Long githubUserId);
+
     boolean isUserAuthorizedToApplyOnProject(Long githubUserId);
 }

--- a/project-domain/src/main/java/onlydust/com/marketplace/project/domain/port/output/GithubAuthenticationInfoPort.java
+++ b/project-domain/src/main/java/onlydust/com/marketplace/project/domain/port/output/GithubAuthenticationInfoPort.java
@@ -3,5 +3,7 @@ package onlydust.com.marketplace.project.domain.port.output;
 import java.util.Set;
 
 public interface GithubAuthenticationInfoPort {
+    void logout(String accessToken);
+
     Set<String> getAuthorizedScopes(String accessToken);
 }

--- a/project-domain/src/main/java/onlydust/com/marketplace/project/domain/port/output/GithubAuthenticationPort.java
+++ b/project-domain/src/main/java/onlydust/com/marketplace/project/domain/port/output/GithubAuthenticationPort.java
@@ -1,7 +1,9 @@
 package onlydust.com.marketplace.project.domain.port.output;
 
+import java.util.Optional;
+
 public interface GithubAuthenticationPort {
     String getGithubPersonalToken(Long githubUserId);
 
-    void logout(Long githubUserId);
+    Optional<String> logout(Long githubUserId);
 }

--- a/project-domain/src/main/java/onlydust/com/marketplace/project/domain/service/GithubUserPermissionsService.java
+++ b/project-domain/src/main/java/onlydust/com/marketplace/project/domain/service/GithubUserPermissionsService.java
@@ -11,6 +11,12 @@ public class GithubUserPermissionsService implements GithubUserPermissionsFacade
     private final GithubAuthenticationInfoPort githubAuthenticationInfoPort;
 
     @Override
+    public void logout(Long githubUserId) {
+        githubAuthenticationPort.logout(githubUserId)
+                .ifPresent(accessToken -> githubAuthenticationInfoPort.logout(accessToken));
+    }
+
+    @Override
     public boolean isUserAuthorizedToApplyOnProject(Long githubUserId) {
         final var accessToken = githubAuthenticationPort.getGithubPersonalToken(githubUserId);
         final var authorizedScopes = githubAuthenticationInfoPort.getAuthorizedScopes(accessToken);


### PR DESCRIPTION
When a user revokes the access of the OAuth app, Auth0 is not aware of it and keeps using its cached personal access token. When logging out on BE side, we need to make sure to clear as well the cache that holds the authorized scopes of a given token.