### PR TITLE
Some caching

### DIFF
--- a/bootstrap/src/main/resources/application.yaml
+++ b/bootstrap/src/main/resources/application.yaml
@@ -56,6 +56,10 @@ application:
     ecosystem-id: ${NODE_GUARDIANS_BOOST_ECOSYSTEM_ID}
   automated-rewards:
     project-lead-id: ${OD_BOT_PROJECT_LEAD_ID}
+  cache:
+    no-cache: ${API_CACHE_NO_CACHE}
+    time-divisor: ${API_CACHE_TIME_DIVISOR}
+    default-stale-while-revalidate-seconds: ${API_CACHE_DEFAULT_STALE_WHILE_REVALIDATE_SECONDS}
 
 spring:
   autoconfigure:

--- a/bootstrap/src/test/resources/application-it.yaml
+++ b/bootstrap/src/test/resources/application-it.yaml
@@ -117,6 +117,11 @@ application:
     ecosystem-id: d6513cd0-824b-4608-ab71-8d57bab6525e # Random value must be overridden in ITs
   automated-rewards:
     project-lead-id: ed648549-39ba-4d73-b67a-5356780a2855  # Random value must be overridden in ITs
+  cache:
+    no-cache: false
+    time-divisor: 1
+    default-stale-while-revalidate-seconds: 10
+
 spring:
   main:
     allow-bean-definition-overriding: true

--- a/load-tests/k6/home.js
+++ b/load-tests/k6/home.js
@@ -1,0 +1,18 @@
+import http from 'k6/http';
+
+export const options = {
+    scenarios: {
+        display_homepage: {
+            executor: 'per-vu-iterations',
+            vus: 20,
+            iterations: 20,
+            startTime: '5s',
+        },
+    },
+};
+
+export default function () {
+    http.get('https://api.onlydust.com/api/v1/projects');
+    http.get('https://api.onlydust.com/api/v1/public-activity?pageIndex=0&pageSize=10');
+    http.get('https://api.onlydust.com/api/v1/hackathons');
+}

--- a/read-api/src/main/java/onlydust/com/marketplace/api/read/ReadApiConfiguration.java
+++ b/read-api/src/main/java/onlydust/com/marketplace/api/read/ReadApiConfiguration.java
@@ -2,9 +2,11 @@ package onlydust.com.marketplace.api.read;
 
 import jakarta.persistence.EntityManager;
 import onlydust.com.marketplace.api.read.mapper.NotificationMapper;
+import onlydust.com.marketplace.api.read.properties.Cache;
 import onlydust.com.marketplace.api.read.repositories.*;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -51,4 +53,11 @@ public class ReadApiConfiguration {
     ) {
         return new AggregatedProjectKpisReadRepository(entityManager);
     }
+
+    @Bean
+    @ConfigurationProperties(value = "application.cache", ignoreUnknownFields = false)
+    public Cache cache() {
+        return new Cache();
+    }
+
 }

--- a/read-api/src/main/java/onlydust/com/marketplace/api/read/adapters/ReadActivityApiPostgresAdapter.java
+++ b/read-api/src/main/java/onlydust/com/marketplace/api/read/adapters/ReadActivityApiPostgresAdapter.java
@@ -30,7 +30,7 @@ public class ReadActivityApiPostgresAdapter implements ReadActivityApi {
         final int sanitizePageSize = sanitizePageSize(pageSize);
         final var page = recentPublicActivityReadRepository.findLastActivity(PageRequest.of(sanitizedPageIndex, sanitizePageSize));
         return ResponseEntity.ok()
-                .cacheControl(cache.maxAgeWithDefaultStale(10, TimeUnit.SECONDS))
+                .cacheControl(cache.forEverybody(10, TimeUnit.SECONDS))
                 .body(new PublicActivityPageResponse()
                         .activities(page.getContent().stream().map(RecentPublicActivityReadEntity::toDto).toList())
                         .totalPageNumber(page.getTotalPages())

--- a/read-api/src/main/java/onlydust/com/marketplace/api/read/adapters/ReadProjectsApiPostgresAdapter.java
+++ b/read-api/src/main/java/onlydust/com/marketplace/api/read/adapters/ReadProjectsApiPostgresAdapter.java
@@ -17,6 +17,7 @@ import onlydust.com.marketplace.api.read.entities.project.*;
 import onlydust.com.marketplace.api.read.mapper.DetailedTotalMoneyMapper;
 import onlydust.com.marketplace.api.read.mapper.RewardsMapper;
 import onlydust.com.marketplace.api.read.mapper.UserMapper;
+import onlydust.com.marketplace.api.read.properties.Cache;
 import onlydust.com.marketplace.api.read.repositories.*;
 import onlydust.com.marketplace.api.rest.api.adapter.authentication.AuthenticatedAppUserService;
 import onlydust.com.marketplace.kernel.exception.OnlyDustException;
@@ -40,6 +41,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
@@ -61,6 +63,7 @@ import static org.springframework.http.ResponseEntity.ok;
 public class ReadProjectsApiPostgresAdapter implements ReadProjectsApi {
     private static final int TOP_CONTRIBUTOR_COUNT = 3;
 
+    private final Cache cache;
     private final AuthenticatedAppUserService authenticatedAppUserService;
     private final PermissionService permissionService;
     private final ProjectGithubIssueItemReadRepository projectGithubIssueItemReadRepository;
@@ -94,11 +97,12 @@ public class ReadProjectsApiPostgresAdapter implements ReadProjectsApi {
         final String tagsJsonPath = getTagsJsonPath(isNull(tags) ? null : tags.stream().map(Enum::name).toList());
         final String languagesJsonPath = getLanguagesJsonPath(languageSlugs);
 
-        return ResponseEntity.ok(user.map(u -> getProjectsForAuthenticatedUser(u.id().value(), mine, search, ecosystemsJsonPath, tagsJsonPath,
-                        languagesJsonPath,
-                        categorySlugs, hasGoodFirstIssues, sanitizePageIndex(pageIndex), sanitizePageSize(pageSize), sort))
-                .orElseGet(() -> getProjectsForAnonymousUser(search, ecosystemsJsonPath, tagsJsonPath, languagesJsonPath, categorySlugs, hasGoodFirstIssues,
-                        sanitizePageIndex(pageIndex), sanitizePageSize(pageSize), sort)));
+        return ResponseEntity.ok()
+                .cacheControl(cache.maxAgeWithDefaultStale(5, TimeUnit.MINUTES))
+                .body(user.map(u -> getProjectsForAuthenticatedUser(u.id().value(), mine, search, ecosystemsJsonPath, tagsJsonPath, languagesJsonPath,
+                                categorySlugs, hasGoodFirstIssues, sanitizePageIndex(pageIndex), sanitizePageSize(pageSize), sort))
+                        .orElseGet(() -> getProjectsForAnonymousUser(search, ecosystemsJsonPath, tagsJsonPath, languagesJsonPath, categorySlugs,
+                                hasGoodFirstIssues, sanitizePageIndex(pageIndex), sanitizePageSize(pageSize), sort)));
     }
 
     private ProjectPageResponse getProjectsForAuthenticatedUser(UUID userId,
@@ -181,7 +185,9 @@ public class ReadProjectsApiPostgresAdapter implements ReadProjectsApi {
         final var project = projectReadRepository.findById(projectId)
                 .orElseThrow(() -> notFound(format("Project %s not found", projectId)));
 
-        return ok(getProjectDetails(project, caller.orElse(null), includeAllAvailableRepos));
+        return ok()
+                .cacheControl(cache.maxAgeWithDefaultStale(5, TimeUnit.MINUTES))
+                .body(getProjectDetails(project, caller.orElse(null), includeAllAvailableRepos));
     }
 
     @Override
@@ -195,7 +201,9 @@ public class ReadProjectsApiPostgresAdapter implements ReadProjectsApi {
         final var project = projectReadRepository.findBySlug(slug)
                 .orElseThrow(() -> notFound(format("Project %s not found", slug)));
 
-        return ok(getProjectDetails(project, caller.orElse(null), includeAllAvailableRepos));
+        return ok()
+                .cacheControl(cache.maxAgeWithDefaultStale(5, TimeUnit.MINUTES))
+                .body(getProjectDetails(project, caller.orElse(null), includeAllAvailableRepos));
     }
 
     @Override
@@ -241,12 +249,14 @@ public class ReadProjectsApiPostgresAdapter implements ReadProjectsApi {
                     case CREATED_AT -> "i.created_at";
                     case CLOSED_AT -> "i.closed_at";
                 })));
-        return ok(new GithubIssuePageResponse()
-                .issues(page.stream().map(i -> i.toPageItemResponse(caller.map(AuthenticatedUser::githubUserId).orElse(null))).toList())
-                .totalPageNumber(page.getTotalPages())
-                .totalItemNumber((int) page.getTotalElements())
-                .hasMore(hasMore(pageIndex, page.getTotalPages()))
-                .nextPageIndex(nextPageIndex(pageIndex, page.getTotalPages())));
+        return ok()
+                .cacheControl(cache.maxAge(10, TimeUnit.SECONDS).mustRevalidate())
+                .body(new GithubIssuePageResponse()
+                        .issues(page.stream().map(i -> i.toPageItemResponse(caller.map(AuthenticatedUser::githubUserId).orElse(null))).toList())
+                        .totalPageNumber(page.getTotalPages())
+                        .totalItemNumber((int) page.getTotalElements())
+                        .hasMore(hasMore(pageIndex, page.getTotalPages()))
+                        .nextPageIndex(nextPageIndex(pageIndex, page.getTotalPages())));
     }
 
     private ProjectResponse getProjectDetails(ProjectReadEntity project, AuthenticatedUser caller, final Boolean includeAllAvailableRepos) {

--- a/read-api/src/main/java/onlydust/com/marketplace/api/read/properties/Cache.java
+++ b/read-api/src/main/java/onlydust/com/marketplace/api/read/properties/Cache.java
@@ -18,18 +18,42 @@ public class Cache {
     private boolean noCache = false;
     private long defaultStaleWhileRevalidateSeconds = 10L;
 
+    /**
+     * Add 'max-age' and 'stale-while-revalidate' headers when the user is anonymous, otherwise add 'max-age' and 'private' headers.
+     * The 'private' header indicates that all or part of the response message is intended for a single user
+     * and MUST NOT be cached by a shared cache.
+     *
+     * @param user   authenticated user (empty if anonymous)
+     * @param maxAge max-age value
+     * @param unit   time unit
+     * @return CacheControl
+     */
     public CacheControl whenAnonymous(Optional<AuthenticatedUser> user, long maxAge, TimeUnit unit) {
         if (user.isEmpty()) {
             return forEverybody(maxAge, unit);
         }
-        return CacheControl.empty().cachePrivate();
+        return sanitize(CacheControl.maxAge(maxAge, unit).cachePrivate());
     }
 
+    /**
+     * Add 'max-age' and 'stale-while-revalidate' headers.
+     *
+     * @param maxAge max-age value
+     * @param unit   time unit
+     * @return CacheControl
+     */
     public CacheControl forEverybody(long maxAge, TimeUnit unit) {
         return sanitize(CacheControl.maxAge(maxAge, unit)
                 .staleWhileRevalidate(Duration.ofSeconds(defaultStaleWhileRevalidateSeconds)));
     }
 
+    /**
+     * Add 'max-age' header.
+     *
+     * @param maxAge max-age value
+     * @param unit   time unit
+     * @return CacheControl
+     */
     public CacheControl maxAge(long maxAge, TimeUnit unit) {
         return sanitize(CacheControl.maxAge(maxAge, unit));
     }

--- a/read-api/src/main/java/onlydust/com/marketplace/api/read/properties/Cache.java
+++ b/read-api/src/main/java/onlydust/com/marketplace/api/read/properties/Cache.java
@@ -1,0 +1,31 @@
+package onlydust.com.marketplace.api.read.properties;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.http.CacheControl;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Cache {
+    private long timeDivisor = 1L;
+    private boolean noCache = false;
+    private long defaultStaleWhileRevalidateSeconds = 10L;
+
+    public CacheControl maxAgeWithDefaultStale(long maxAge, TimeUnit unit) {
+        return sanitize(CacheControl.maxAge(maxAge, unit)
+                .staleWhileRevalidate(Duration.ofSeconds(defaultStaleWhileRevalidateSeconds)));
+    }
+
+    public CacheControl maxAge(long maxAge, TimeUnit unit) {
+        return sanitize(CacheControl.maxAge(Duration.ofSeconds(unit.toSeconds(maxAge))));
+    }
+
+    private CacheControl sanitize(CacheControl cacheControl) {
+        return noCache ? CacheControl.noCache() : cacheControl;
+    }
+}

--- a/read-api/src/main/java/onlydust/com/marketplace/api/read/properties/Cache.java
+++ b/read-api/src/main/java/onlydust/com/marketplace/api/read/properties/Cache.java
@@ -32,7 +32,7 @@ public class Cache {
         if (user.isEmpty()) {
             return forEverybody(maxAge, unit);
         }
-        return sanitize(CacheControl.maxAge(maxAge, unit).cachePrivate());
+        return sanitize(maxAge(maxAge, unit).cachePrivate());
     }
 
     /**
@@ -43,7 +43,7 @@ public class Cache {
      * @return CacheControl
      */
     public CacheControl forEverybody(long maxAge, TimeUnit unit) {
-        return sanitize(CacheControl.maxAge(maxAge, unit)
+        return sanitize(maxAge(maxAge, unit)
                 .staleWhileRevalidate(Duration.ofSeconds(defaultStaleWhileRevalidateSeconds)));
     }
 
@@ -54,8 +54,8 @@ public class Cache {
      * @param unit   time unit
      * @return CacheControl
      */
-    public CacheControl maxAge(long maxAge, TimeUnit unit) {
-        return sanitize(CacheControl.maxAge(maxAge, unit));
+    private CacheControl maxAge(long maxAge, TimeUnit unit) {
+        return CacheControl.maxAge(Duration.ofSeconds(unit.toSeconds(maxAge)).dividedBy(timeDivisor));
     }
 
     private CacheControl sanitize(CacheControl cacheControl) {

--- a/read-api/src/test/java/onlydust/com/marketplace/api/read/CacheTest.java
+++ b/read-api/src/test/java/onlydust/com/marketplace/api/read/CacheTest.java
@@ -28,9 +28,9 @@ class CacheTest {
         assertThat(cache.forEverybody(maxAgeSeconds, TimeUnit.SECONDS).getHeaderValue())
                 .isEqualTo("max-age=%d, stale-while-revalidate=10".formatted(expectedSeconds));
         assertThat(cache.whenAnonymous(Optional.empty(), maxAgeSeconds, TimeUnit.SECONDS).getHeaderValue())
-                .isEqualTo(("max-age=%d, stale-while-revalidate=10").formatted(expectedSeconds));
+                .isEqualTo("max-age=%d, stale-while-revalidate=10".formatted(expectedSeconds));
         assertThat(cache.whenAnonymous(Optional.of(AuthenticatedUser.builder().build()), maxAgeSeconds, TimeUnit.SECONDS).getHeaderValue())
-                .isEqualTo("private");
+                .isEqualTo("max-age=%d, private".formatted(expectedSeconds));
     }
 
     @ParameterizedTest
@@ -48,9 +48,9 @@ class CacheTest {
         assertThat(cache.forEverybody(maxAgeMinutes, TimeUnit.MINUTES).getHeaderValue())
                 .isEqualTo("max-age=%d, stale-while-revalidate=10".formatted(expectedSeconds));
         assertThat(cache.whenAnonymous(Optional.empty(), maxAgeMinutes, TimeUnit.MINUTES).getHeaderValue())
-                .isEqualTo(("max-age=%d, stale-while-revalidate=10").formatted(expectedSeconds));
+                .isEqualTo("max-age=%d, stale-while-revalidate=10".formatted(expectedSeconds));
         assertThat(cache.whenAnonymous(Optional.of(AuthenticatedUser.builder().build()), maxAgeMinutes, TimeUnit.MINUTES).getHeaderValue())
-                .isEqualTo("private");
+                .isEqualTo("max-age=%d, private".formatted(expectedSeconds));
     }
 
     @Test
@@ -58,6 +58,8 @@ class CacheTest {
         final var cache = new Cache(1L, true, 10);
         assertThat(cache.maxAge(20, TimeUnit.SECONDS).getHeaderValue()).isEqualTo("no-store");
         assertThat(cache.forEverybody(20, TimeUnit.SECONDS).getHeaderValue()).isEqualTo("no-store");
+        assertThat(cache.whenAnonymous(Optional.empty(), 20, TimeUnit.MINUTES).getHeaderValue()).isEqualTo("no-store");
+        assertThat(cache.whenAnonymous(Optional.of(AuthenticatedUser.builder().build()), 20, TimeUnit.MINUTES).getHeaderValue()).isEqualTo("no-store");
     }
 
     @Test

--- a/read-api/src/test/java/onlydust/com/marketplace/api/read/CacheTest.java
+++ b/read-api/src/test/java/onlydust/com/marketplace/api/read/CacheTest.java
@@ -1,10 +1,12 @@
 package onlydust.com.marketplace.api.read;
 
 import onlydust.com.marketplace.api.read.properties.Cache;
+import onlydust.com.marketplace.kernel.model.AuthenticatedUser;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,8 +23,14 @@ class CacheTest {
             """)
     void maxAge(long maxAgeSeconds, long maxAgeDivisor, long expectedSeconds) {
         final var cache = new Cache(maxAgeDivisor, false, 10);
-        assertThat(cache.maxAge(maxAgeSeconds, TimeUnit.SECONDS).getHeaderValue()).isEqualTo("max-age=%d".formatted(expectedSeconds));
-        assertThat(cache.maxAgeWithDefaultStale(maxAgeSeconds, TimeUnit.SECONDS).getHeaderValue()).isEqualTo("max-age=%d, stale-while-revalidate=10".formatted(expectedSeconds));
+        assertThat(cache.maxAge(maxAgeSeconds, TimeUnit.SECONDS).getHeaderValue())
+                .isEqualTo("max-age=%d".formatted(expectedSeconds));
+        assertThat(cache.forEverybody(maxAgeSeconds, TimeUnit.SECONDS).getHeaderValue())
+                .isEqualTo("max-age=%d, stale-while-revalidate=10".formatted(expectedSeconds));
+        assertThat(cache.whenAnonymous(Optional.empty(), maxAgeSeconds, TimeUnit.SECONDS).getHeaderValue())
+                .isEqualTo(("max-age=%d, stale-while-revalidate=10").formatted(expectedSeconds));
+        assertThat(cache.whenAnonymous(Optional.of(AuthenticatedUser.builder().build()), maxAgeSeconds, TimeUnit.SECONDS).getHeaderValue())
+                .isEqualTo("private");
     }
 
     @ParameterizedTest
@@ -33,22 +41,28 @@ class CacheTest {
             10, 4, 150
             10, 2000, 0
             """)
-    void maxAgeMinutes(long maxAgeMinutes, long maxAgeDivisor, long expectedSeconds) {
+    void cache(long maxAgeMinutes, long maxAgeDivisor, long expectedSeconds) {
         final var cache = new Cache(maxAgeDivisor, false, 10);
-        assertThat(cache.maxAge(maxAgeMinutes, TimeUnit.MINUTES).getHeaderValue()).isEqualTo("max-age=%d".formatted(expectedSeconds));
-        assertThat(cache.maxAgeWithDefaultStale(maxAgeMinutes, TimeUnit.MINUTES).getHeaderValue()).isEqualTo("max-age=%d, stale-while-revalidate=10".formatted(expectedSeconds));
+        assertThat(cache.maxAge(maxAgeMinutes, TimeUnit.MINUTES).getHeaderValue())
+                .isEqualTo("max-age=%d".formatted(expectedSeconds));
+        assertThat(cache.forEverybody(maxAgeMinutes, TimeUnit.MINUTES).getHeaderValue())
+                .isEqualTo("max-age=%d, stale-while-revalidate=10".formatted(expectedSeconds));
+        assertThat(cache.whenAnonymous(Optional.empty(), maxAgeMinutes, TimeUnit.MINUTES).getHeaderValue())
+                .isEqualTo(("max-age=%d, stale-while-revalidate=10").formatted(expectedSeconds));
+        assertThat(cache.whenAnonymous(Optional.of(AuthenticatedUser.builder().build()), maxAgeMinutes, TimeUnit.MINUTES).getHeaderValue())
+                .isEqualTo("private");
     }
 
     @Test
     void noCache() {
         final var cache = new Cache(1L, true, 10);
-        assertThat(cache.maxAge(20, TimeUnit.SECONDS).getHeaderValue()).isEqualTo("no-cache");
-        assertThat(cache.maxAgeWithDefaultStale(20, TimeUnit.SECONDS).getHeaderValue()).isEqualTo("no-cache");
+        assertThat(cache.maxAge(20, TimeUnit.SECONDS).getHeaderValue()).isEqualTo("no-store");
+        assertThat(cache.forEverybody(20, TimeUnit.SECONDS).getHeaderValue()).isEqualTo("no-store");
     }
 
     @Test
     void defaultStale() {
         final var cache = new Cache(1L, false, 40);
-        assertThat(cache.maxAgeWithDefaultStale(20, TimeUnit.SECONDS).getHeaderValue()).isEqualTo("max-age=20, stale-while-revalidate=40");
+        assertThat(cache.forEverybody(20, TimeUnit.SECONDS).getHeaderValue()).isEqualTo("max-age=20, stale-while-revalidate=40");
     }
 }

--- a/read-api/src/test/java/onlydust/com/marketplace/api/read/CacheTest.java
+++ b/read-api/src/test/java/onlydust/com/marketplace/api/read/CacheTest.java
@@ -1,0 +1,54 @@
+package onlydust.com.marketplace.api.read;
+
+import onlydust.com.marketplace.api.read.properties.Cache;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CacheTest {
+
+    @ParameterizedTest
+    @CsvSource("""
+            10, 1, 10
+            10, 2, 5
+            10, 3, 3
+            10, 4, 2
+            10, 20, 0
+            """)
+    void maxAge(long maxAgeSeconds, long maxAgeDivisor, long expectedSeconds) {
+        final var cache = new Cache(maxAgeDivisor, false, 10);
+        assertThat(cache.maxAge(maxAgeSeconds, TimeUnit.SECONDS).getHeaderValue()).isEqualTo("max-age=%d".formatted(expectedSeconds));
+        assertThat(cache.maxAgeWithDefaultStale(maxAgeSeconds, TimeUnit.SECONDS).getHeaderValue()).isEqualTo("max-age=%d, stale-while-revalidate=10".formatted(expectedSeconds));
+    }
+
+    @ParameterizedTest
+    @CsvSource("""
+            10, 1, 600
+            10, 2, 300
+            10, 3, 200
+            10, 4, 150
+            10, 2000, 0
+            """)
+    void maxAgeMinutes(long maxAgeMinutes, long maxAgeDivisor, long expectedSeconds) {
+        final var cache = new Cache(maxAgeDivisor, false, 10);
+        assertThat(cache.maxAge(maxAgeMinutes, TimeUnit.MINUTES).getHeaderValue()).isEqualTo("max-age=%d".formatted(expectedSeconds));
+        assertThat(cache.maxAgeWithDefaultStale(maxAgeMinutes, TimeUnit.MINUTES).getHeaderValue()).isEqualTo("max-age=%d, stale-while-revalidate=10".formatted(expectedSeconds));
+    }
+
+    @Test
+    void noCache() {
+        final var cache = new Cache(1L, true, 10);
+        assertThat(cache.maxAge(20, TimeUnit.SECONDS).getHeaderValue()).isEqualTo("no-cache");
+        assertThat(cache.maxAgeWithDefaultStale(20, TimeUnit.SECONDS).getHeaderValue()).isEqualTo("no-cache");
+    }
+
+    @Test
+    void defaultStale() {
+        final var cache = new Cache(1L, false, 40);
+        assertThat(cache.maxAgeWithDefaultStale(20, TimeUnit.SECONDS).getHeaderValue()).isEqualTo("max-age=20, stale-while-revalidate=40");
+    }
+}

--- a/read-api/src/test/java/onlydust/com/marketplace/api/read/CacheTest.java
+++ b/read-api/src/test/java/onlydust/com/marketplace/api/read/CacheTest.java
@@ -14,17 +14,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CacheTest {
 
     @ParameterizedTest
-    @CsvSource("""
-            10, 1, 10
-            10, 2, 5
-            10, 3, 3
-            10, 4, 2
-            10, 20, 0
-            """)
+    @CsvSource({
+            "10, 1, 10",
+            "10, 2, 5",
+            "10, 3, 3",
+            "10, 4, 2",
+            "10, 20, 0"
+    })
     void maxAge(long maxAgeSeconds, long maxAgeDivisor, long expectedSeconds) {
         final var cache = new Cache(maxAgeDivisor, false, 10);
-        assertThat(cache.maxAge(maxAgeSeconds, TimeUnit.SECONDS).getHeaderValue())
-                .isEqualTo("max-age=%d".formatted(expectedSeconds));
         assertThat(cache.forEverybody(maxAgeSeconds, TimeUnit.SECONDS).getHeaderValue())
                 .isEqualTo("max-age=%d, stale-while-revalidate=10".formatted(expectedSeconds));
         assertThat(cache.whenAnonymous(Optional.empty(), maxAgeSeconds, TimeUnit.SECONDS).getHeaderValue())
@@ -34,17 +32,15 @@ class CacheTest {
     }
 
     @ParameterizedTest
-    @CsvSource("""
-            10, 1, 600
-            10, 2, 300
-            10, 3, 200
-            10, 4, 150
-            10, 2000, 0
-            """)
+    @CsvSource({
+            "10, 1, 600",
+            "10, 2, 300",
+            "10, 3, 200",
+            "10, 4, 150",
+            "10, 2000, 0"
+    })
     void cache(long maxAgeMinutes, long maxAgeDivisor, long expectedSeconds) {
         final var cache = new Cache(maxAgeDivisor, false, 10);
-        assertThat(cache.maxAge(maxAgeMinutes, TimeUnit.MINUTES).getHeaderValue())
-                .isEqualTo("max-age=%d".formatted(expectedSeconds));
         assertThat(cache.forEverybody(maxAgeMinutes, TimeUnit.MINUTES).getHeaderValue())
                 .isEqualTo("max-age=%d, stale-while-revalidate=10".formatted(expectedSeconds));
         assertThat(cache.whenAnonymous(Optional.empty(), maxAgeMinutes, TimeUnit.MINUTES).getHeaderValue())
@@ -56,7 +52,6 @@ class CacheTest {
     @Test
     void noCache() {
         final var cache = new Cache(1L, true, 10);
-        assertThat(cache.maxAge(20, TimeUnit.SECONDS).getHeaderValue()).isEqualTo("no-store");
         assertThat(cache.forEverybody(20, TimeUnit.SECONDS).getHeaderValue()).isEqualTo("no-store");
         assertThat(cache.whenAnonymous(Optional.empty(), 20, TimeUnit.MINUTES).getHeaderValue()).isEqualTo("no-store");
         assertThat(cache.whenAnonymous(Optional.of(AuthenticatedUser.builder().build()), 20, TimeUnit.MINUTES).getHeaderValue()).isEqualTo("no-store");


### PR DESCRIPTION
The `Cache` properties allows to 

- disable cache (`no-cache=true`)
- reduce all cache TTLs by dividing them (`time-divisor=10`). This allows to set smaller TTLs on `develop` and `staging` for example.
- set the default stale-while-revalidate (`default-stale-while-revalidate-seconds=30`)